### PR TITLE
fix incomplete tel: attribute for support phone number

### DIFF
--- a/src/app/data/help.js
+++ b/src/app/data/help.js
@@ -16,7 +16,7 @@ const help = [
 		icon: 'phone',
 		Svg: Phone,
 		cta: __('Call Us', 'wp-plugin-hostgator'),
-		url: 'tel:(866)_964-286',
+		url: 'tel:(866)_964-2867',
 	},
 	{
 		name: 'chat',

--- a/src/app/data/help.js
+++ b/src/app/data/help.js
@@ -16,7 +16,7 @@ const help = [
 		icon: 'phone',
 		Svg: Phone,
 		cta: __('Call Us', 'wp-plugin-hostgator'),
-		url: 'tel:(866)_964-2867',
+		url: 'tel:8669642867',
 	},
 	{
 		name: 'chat',


### PR DESCRIPTION
Oops, left off a digit to the phone number! This adds it in for folks who will dial directly from the button.