### PR TITLE
Fix/wordpress version compats

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -117,7 +117,7 @@ final class Admin {
 		}
 
 		echo '<!-- /HostGator -->' . PHP_EOL;
-		
+
 	}
 
 	/**

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -97,9 +97,27 @@ final class Admin {
 	 * @return void
 	 */
 	public static function render() {
+		global $wp_version;
+
 		echo '<!-- HostGator -->' . PHP_EOL;
-		echo '<div id="hwa-app" class="hgwpp hgwpp_app"></div>' . PHP_EOL;
+
+		if ( version_compare( $wp_version, '5.4', '>=' ) ) {
+			echo '<div id="hwa-app" class="hgwpp hgwpp_app"></div>' . PHP_EOL;
+		} else {
+			// fallback messaging for WordPress older than 5.4
+			echo '<div id="hwa-app" class="hgwpp hgwpp_app">' . PHP_EOL;
+			echo '<header class="hgwp-header" style="min-height: 90px; padding: 1rem; margin-bottom: 1.5rem;"><div class="hgwp-header-inner"><div class="hgwp-logo-wrap">' . PHP_EOL;
+			echo '<img src="' . esc_url( HOSTGATOR_PLUGIN_URL . 'assets/svg/nav-for-light.svg' ) . '" alt="HostGator logo" />' . PHP_EOL;
+			echo '</div></div></header>' . PHP_EOL;
+			echo '<div class="wrap">' . PHP_EOL;
+			echo '<div class="card" style="margin-left: 20px;"><h2 class="title">' . esc_html__( 'Please update to a newer WordPress version.', 'wp-plugin-hostgator' ) . '</h2>' . PHP_EOL;
+			echo '<p>' . esc_html__( 'There are new WordPress components which this plugin requires in order to render the interface.', 'wp-plugin-hostgator' ) . '</p>' . PHP_EOL;
+			echo '<p><a href="' . esc_url( admin_url( 'update-core.php' ) ) . '" class="button component-button is-primary button-primary" variant="primary">' . esc_html__( 'Please update now', 'wp-plugin-hostgator' ) . '</a></p>' . PHP_EOL;
+			echo '</div></div></div>' . PHP_EOL;
+		}
+
 		echo '<!-- /HostGator -->' . PHP_EOL;
+		
 	}
 
 	/**

--- a/languages/wp-plugin-hostgator.pot
+++ b/languages/wp-plugin-hostgator.pot
@@ -35,7 +35,7 @@ msgid "Please install the HostGator Plugin dependencies."
 msgstr ""
 
 #: inc/Admin.php:42
-#: inc/Admin.php:157
+#: inc/Admin.php:175
 #: src/app/data/routes.js:51
 msgid "Home"
 msgstr ""
@@ -56,7 +56,7 @@ msgid "Performance"
 msgstr ""
 
 #: inc/Admin.php:45
-#: inc/Admin.php:158
+#: inc/Admin.php:176
 #: src/app/data/routes.js:69
 #: src/app/pages/home/settingsSection.js:54
 #: src/app/pages/performance/settingsCallout.js:17
@@ -70,7 +70,19 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: inc/Admin.php:171
+#: inc/Admin.php:113
+msgid "Please update to a newer WordPress version."
+msgstr ""
+
+#: inc/Admin.php:114
+msgid "There are new WordPress components which this plugin requires in order to render the interface."
+msgstr ""
+
+#: inc/Admin.php:115
+msgid "Please update now"
+msgstr ""
+
+#: inc/Admin.php:189
 msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://hostgator.com/about\">HostGator</a>."
 msgstr ""
 
@@ -213,23 +225,23 @@ msgstr ""
 msgid "Auto-updates enabled"
 msgstr ""
 
-#: src/app/components/errorCard/index.js:24
+#: src/app/components/errorCard/index.js:23
 msgid "Oh No, An Error!"
 msgstr ""
 
-#: src/app/components/errorCard/index.js:28
+#: src/app/components/errorCard/index.js:27
 msgid "You found an error, please refresh the page and try again!"
 msgstr ""
 
-#: src/app/components/errorCard/index.js:29
+#: src/app/components/errorCard/index.js:28
 msgid "If the error persists, please contact support."
 msgstr ""
 
-#: src/app/components/errorCard/index.js:34
+#: src/app/components/errorCard/index.js:33
 msgid " Error code: "
 msgstr ""
 
-#: src/app/components/header/logo.js:17
+#: src/app/components/header/logo.js:15
 msgid "HostGator WordPress Plugin"
 msgstr ""
 
@@ -427,43 +439,43 @@ msgstr ""
 msgid "Daisy is the #1 blog theme on the marketplace!"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:28
-#: src/app/pages/settings/comingSoon.js:61
-#: src/app/pages/settings/comingSoon.js:73
+#: src/app/pages/home/comingSoonSection.js:27
+#: src/app/pages/settings/comingSoon.js:59
+#: src/app/pages/settings/comingSoon.js:71
 msgid "Coming Soon"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:29
+#: src/app/pages/home/comingSoonSection.js:28
 msgid "Site Launched!"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:33
+#: src/app/pages/home/comingSoonSection.js:32
 msgid "Your site currently displays a coming soon page to visitors. Once you have finished setting up your site, be sure to launch it so your visitors can reach it."
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:37
+#: src/app/pages/home/comingSoonSection.js:36
 msgid "Congratulations! You just successfully launched your site! Visitors will now see the site, you can easily undo this and restore the coming soon page if you are not ready."
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:57
+#: src/app/pages/home/comingSoonSection.js:56
 msgid "Launch Site"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:69
+#: src/app/pages/home/comingSoonSection.js:68
 msgid "Restore Coming Soon"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:78
+#: src/app/pages/home/comingSoonSection.js:77
 msgid "Dismiss"
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:85
-#: src/app/pages/settings/comingSoon.js:27
+#: src/app/pages/home/comingSoonSection.js:84
+#: src/app/pages/settings/comingSoon.js:25
 msgid "Coming soon activated."
 msgstr ""
 
-#: src/app/pages/home/comingSoonSection.js:86
-#: src/app/pages/settings/comingSoon.js:28
+#: src/app/pages/home/comingSoonSection.js:85
+#: src/app/pages/settings/comingSoon.js:26
 msgid "Coming soon deactivated."
 msgstr ""
 
@@ -595,89 +607,89 @@ msgstr ""
 msgid "Get Help"
 msgstr ""
 
-#: src/app/pages/marketplace/plugins.js:9
-#: src/app/pages/settings/automaticUpdates.js:211
+#: src/app/pages/marketplace/plugins.js:8
+#: src/app/pages/settings/automaticUpdates.js:210
 msgid "Plugins"
 msgstr ""
 
-#: src/app/pages/marketplace/services.js:9
+#: src/app/pages/marketplace/services.js:8
 msgid "Services"
 msgstr ""
 
-#: src/app/pages/marketplace/themes.js:9
-#: src/app/pages/settings/automaticUpdates.js:226
+#: src/app/pages/marketplace/themes.js:8
+#: src/app/pages/settings/automaticUpdates.js:225
 msgid "Themes"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:27
+#: src/app/pages/performance/cacheSettings.js:26
 msgid "Disabled"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:30
+#: src/app/pages/performance/cacheSettings.js:29
 msgid "No cache enabled."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:33
+#: src/app/pages/performance/cacheSettings.js:32
 msgid "Not recommended."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:44
+#: src/app/pages/performance/cacheSettings.js:43
 msgid "Assets Only"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:47
+#: src/app/pages/performance/cacheSettings.js:46
 msgid "Cache static assets like images and the appearance of your site for 1 hour."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:53
+#: src/app/pages/performance/cacheSettings.js:52
 msgid "Recommended for ecommerce and sites that update frequently or display info in real-time."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:67
+#: src/app/pages/performance/cacheSettings.js:66
 msgid "Assets & Web Pages"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:70
+#: src/app/pages/performance/cacheSettings.js:69
 msgid "Cache static assets for 24 hours and web pages for 2 hours."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:76
+#: src/app/pages/performance/cacheSettings.js:75
 msgid "Recommended for blogs, educational sites, and sites that update at least weekly."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:90
+#: src/app/pages/performance/cacheSettings.js:89
 msgid "Assets & Web Pages - Extended"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:96
+#: src/app/pages/performance/cacheSettings.js:95
 msgid "Cache static assets for 1 week and web pages for 8 hours."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:102
+#: src/app/pages/performance/cacheSettings.js:101
 msgid "Recommended for portfolios, brochure sites, and sites that update monthly or less often."
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:135
+#: src/app/pages/performance/cacheSettings.js:134
 msgid "Cache Level"
 msgstr ""
 
-#: src/app/pages/performance/cacheSettings.js:139
+#: src/app/pages/performance/cacheSettings.js:138
 msgid "Boost speed and performance by storing a copy of your website content, files, and images online so the pages of your website load faster for your visitors."
 msgstr ""
 
-#: src/app/pages/performance/clearCache.js:21
+#: src/app/pages/performance/clearCache.js:20
 msgid "Cache cleared"
 msgstr ""
 
-#: src/app/pages/performance/clearCache.js:37
+#: src/app/pages/performance/clearCache.js:36
 msgid "Clear Cache"
 msgstr ""
 
-#: src/app/pages/performance/clearCache.js:41
+#: src/app/pages/performance/clearCache.js:40
 msgid "If you’ve recently updated your website, we recommend clearing the site cache. We’ll fetch a fresh version of your site to cache."
 msgstr ""
 
-#: src/app/pages/performance/clearCache.js:54
+#: src/app/pages/performance/clearCache.js:53
 msgid "Clear All Cache Now"
 msgstr ""
 
@@ -685,217 +697,217 @@ msgstr ""
 msgid "Performance illustration"
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:37
+#: src/app/pages/settings/automaticUpdates.js:36
 msgid "Everything will auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:38
+#: src/app/pages/settings/automaticUpdates.js:37
 msgid "Custom auto-update settings."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:42
+#: src/app/pages/settings/automaticUpdates.js:41
 msgid "Yay! Everything will automatically update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:46
+#: src/app/pages/settings/automaticUpdates.js:45
 msgid "Custom automatic update settings."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:53
+#: src/app/pages/settings/automaticUpdates.js:52
 msgid "Core will auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:54
+#: src/app/pages/settings/automaticUpdates.js:53
 msgid "Core will not auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:58
+#: src/app/pages/settings/automaticUpdates.js:57
 msgid "WordPress will automatically update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:62
+#: src/app/pages/settings/automaticUpdates.js:61
 msgid "WordPress must be manually updated."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:69
+#: src/app/pages/settings/automaticUpdates.js:68
 msgid "Plugins will auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:70
+#: src/app/pages/settings/automaticUpdates.js:69
 msgid "Plugins will not auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:77
+#: src/app/pages/settings/automaticUpdates.js:76
 msgid "All plugins will automatically update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:81
+#: src/app/pages/settings/automaticUpdates.js:80
 msgid "Each plugin must be manually updated."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:88
+#: src/app/pages/settings/automaticUpdates.js:87
 msgid "Themes will auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:89
+#: src/app/pages/settings/automaticUpdates.js:88
 msgid "Theme will not auto-update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:96
+#: src/app/pages/settings/automaticUpdates.js:95
 msgid "All themes will automatically update."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:100
+#: src/app/pages/settings/automaticUpdates.js:99
 msgid "Each theme must be manually updated."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:168
+#: src/app/pages/settings/automaticUpdates.js:167
 msgid "Automatic Updates"
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:172
+#: src/app/pages/settings/automaticUpdates.js:171
 msgid "Allow your site to stay updated automatically."
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:182
+#: src/app/pages/settings/automaticUpdates.js:181
 msgid "Everything"
 msgstr ""
 
-#: src/app/pages/settings/automaticUpdates.js:196
+#: src/app/pages/settings/automaticUpdates.js:195
 msgid "Core"
 msgstr ""
 
-#: src/app/pages/settings/comingSoon.js:32
+#: src/app/pages/settings/comingSoon.js:30
 msgid "Coming soon page is active and site is protected."
 msgstr ""
 
-#: src/app/pages/settings/comingSoon.js:36
+#: src/app/pages/settings/comingSoon.js:34
 msgid "Coming soon page is not active and site is acessible."
 msgstr ""
 
-#: src/app/pages/settings/comingSoon.js:65
+#: src/app/pages/settings/comingSoon.js:63
 msgid "Not ready for your site to be live? Enable a \"Coming Soon\" page while you build your website for the public eye. This will disable all parts of your site and show visitors a \"coming soon\" landing page."
 msgstr ""
 
-#: src/app/pages/settings/comingSoon.js:84
+#: src/app/pages/settings/comingSoon.js:82
 msgid "Pro Tip: Begin collecting subscribers"
 msgstr ""
 
-#: src/app/pages/settings/comingSoon.js:89
+#: src/app/pages/settings/comingSoon.js:87
 msgid "First, activate the \"Jetpack\" plugin, connect your site, and enable the \"Subscriptions\" module. Then, users can subsribe to be notified when you launch and publish new content."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:35
+#: src/app/pages/settings/commentSettings.js:34
 msgid "Comments on old posts are disabled."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:39
+#: src/app/pages/settings/commentSettings.js:38
 msgid "Comments are allowed on old posts."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:46
+#: src/app/pages/settings/commentSettings.js:45
 msgid "Old post comments disabled."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:47
+#: src/app/pages/settings/commentSettings.js:46
 msgid "Old post comments enabled."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:53
+#: src/app/pages/settings/commentSettings.js:52
 msgid "Close comments after "
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:55
-#: src/app/pages/settings/commentSettings.js:73
-#: src/app/pages/settings/commentSettings.js:89
+#: src/app/pages/settings/commentSettings.js:54
+#: src/app/pages/settings/commentSettings.js:72
+#: src/app/pages/settings/commentSettings.js:88
 msgid " day."
 msgid_plural " days."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/commentSettings.js:68
+#: src/app/pages/settings/commentSettings.js:67
 msgid "Comments on posts are disabled after "
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:84
+#: src/app/pages/settings/commentSettings.js:83
 msgid "Disabled comments on posts older than "
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:101
+#: src/app/pages/settings/commentSettings.js:100
 msgid "Display "
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:103
+#: src/app/pages/settings/commentSettings.js:102
 msgid " comment per page."
 msgid_plural " comments per page."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/commentSettings.js:116
+#: src/app/pages/settings/commentSettings.js:115
 msgid "Posts will display "
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:118
+#: src/app/pages/settings/commentSettings.js:117
 msgid " comment at a time."
 msgid_plural " comments at a time."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/commentSettings.js:128
+#: src/app/pages/settings/commentSettings.js:127
 msgid "Comments per page setting saved."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:172
+#: src/app/pages/settings/commentSettings.js:171
 msgid "Comments"
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:176
+#: src/app/pages/settings/commentSettings.js:175
 msgid "Make blog post comments disabled on older posts and control how many to display."
 msgstr ""
 
-#: src/app/pages/settings/commentSettings.js:187
+#: src/app/pages/settings/commentSettings.js:186
 msgid "Disable comments for older posts"
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:32
+#: src/app/pages/settings/contentSettings.js:31
 msgid "Keep "
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:34
+#: src/app/pages/settings/contentSettings.js:33
 msgid " latest revision"
 msgid_plural " latest revisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/contentSettings.js:47
+#: src/app/pages/settings/contentSettings.js:46
 msgid "Posts will save "
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:49
+#: src/app/pages/settings/contentSettings.js:48
 msgid " revision."
 msgid_plural " revisions."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/contentSettings.js:65
+#: src/app/pages/settings/contentSettings.js:64
 msgid "Empty trash every "
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:67
-#: src/app/pages/settings/contentSettings.js:85
+#: src/app/pages/settings/contentSettings.js:66
+#: src/app/pages/settings/contentSettings.js:84
 msgid " week."
 msgid_plural " weeks."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/app/pages/settings/contentSettings.js:80
+#: src/app/pages/settings/contentSettings.js:79
 msgid "The trash will automatically empty every "
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:126
+#: src/app/pages/settings/contentSettings.js:125
 msgid "Content Options"
 msgstr ""
 
-#: src/app/pages/settings/contentSettings.js:130
+#: src/app/pages/settings/contentSettings.js:129
 msgid "Controls for content revisions and how often to empty the trash."
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-plugin-hostgator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/app/components/errorCard/index.js
+++ b/src/app/components/errorCard/index.js
@@ -1,16 +1,15 @@
 import './stylesheet.scss';
+import { Heading } from '../../components';
 import {
-	Button,
+    dispatchUpdateSnackbar,
+} from '../../util/helpers';
+import {
 	Card,
 	CardBody,
 	CardHeader,
 	CardFooter,
-	Dashicon,
-	__experimentalHeading as Heading,
+	Dashicon
 } from '@wordpress/components';
-import {
-	dispatchUpdateSnackbar,
-} from '../../util/helpers';
 
 const ErrorCard = ({ error, className, notice = 'Error!' }) => {
     dispatchUpdateSnackbar(notice);

--- a/src/app/components/header/logo.js
+++ b/src/app/components/header/logo.js
@@ -1,8 +1,6 @@
-import {
-	Button,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { Heading } from '../../components';
 import { ReactComponent as Brand } from '../../../../assets/svg/nav-for-light.svg';
+import { Button } from '@wordpress/components';
 
 const Logo = () => {
 	return (

--- a/src/app/components/heading/index.js
+++ b/src/app/components/heading/index.js
@@ -1,0 +1,11 @@
+const Heading = ({ level, className, children }) => {
+	const TagName = 'h' + level;
+
+	return (
+		<TagName className={classNames('heading', className)}>
+            { children }
+        </TagName>
+	);
+};
+
+export default Heading;

--- a/src/app/components/index.js
+++ b/src/app/components/index.js
@@ -1,0 +1,5 @@
+export { default as Accordion } from './accordion';
+export { default as ErrorCard } from './errorCard';
+export { default as Header } from './header';
+export { default as Heading } from './heading';
+export { default as MarketplaceItem } from './marketplaceItem';

--- a/src/app/components/marketplaceItem/index.js
+++ b/src/app/components/marketplaceItem/index.js
@@ -1,11 +1,11 @@
+import { Heading } from '../../components';
 import {
 	Button,
 	Card,
 	CardBody,
 	CardHeader,
 	CardFooter,
-	CardMedia,
-	__experimentalHeading as Heading,
+	CardMedia
 } from '@wordpress/components';
 
 const MarketplaceItem = ({ item }) => {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -15,6 +15,9 @@ import { store as noticesStore } from '@wordpress/notices';
 import { setActiveSubnav } from './util/helpers';
 
 const Notices = () => {
+	if ( 'undefined' === typeof noticesStore ) {
+		return null;
+	}
 	const notices = useSelect(
 		(select) =>
 			select(noticesStore)

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -55,7 +55,7 @@ const AppBody = (props) => {
 	return (
 		<main
 			id="hgwp-app-rendered"
-			className={classnames('wpadmin-brand-hostgator', props.className)}
+			className={classnames('wpadmin-brand-web', `hgwp-wp-${HGWP.wpversion}`, props.className)}
 		>
 			<Header />
 			<div className="hgwp-app-body">

--- a/src/app/pages/help/index.js
+++ b/src/app/pages/help/index.js
@@ -1,4 +1,6 @@
 import './stylesheet.scss';
+import { Heading } from '../../components';
+import help from '../../data/help';
 import {
 	Button,
 	Card,
@@ -7,8 +9,6 @@ import {
 	CardFooter,
 	Dashicon,
 } from '@wordpress/components';
-import { __experimentalHeading as Heading } from '@wordpress/components';
-import help from '../../data/help';
 
 const Help = () => {
 	return (

--- a/src/app/pages/help/stylesheet.scss
+++ b/src/app/pages/help/stylesheet.scss
@@ -1,7 +1,8 @@
 .card-help {
     text-align: center;
 
-    svg {
+    .components-card-body svg,
+    .components-card__body svg {
         width: 100px;
         height: 100px;
     }
@@ -11,4 +12,11 @@
         flex-direction: column;
         justify-content: end;
     }
+
+    /* <= WP 5.8 */
+    .components-card__header,
+    .components-card__footer {
+        justify-content: center;
+    }
+
 }

--- a/src/app/pages/home/comingSoonSection.js
+++ b/src/app/pages/home/comingSoonSection.js
@@ -1,21 +1,20 @@
+import AppStore from '../../data/store';
+import { ErrorCard, Heading } from '../../components';
+import {
+	hostgatorSettingsApiFetch,
+	dispatchUpdateSnackbar,
+	comingSoonAdminbarToggle
+} from '../../util/helpers';
 import snappyUrl from '../../../../assets/svg/snappy-holding-site-left.svg';
 import {
 	Button,
 	Card,
 	CardBody,
 	CardHeader,
-	CardFooter,
-	__experimentalHeading as Heading,
+	CardFooter
 } from '@wordpress/components';
-import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
 import { useState } from '@wordpress/element';
 import { useUpdateEffect } from 'react-use';
-import {
-	hostgatorSettingsApiFetch,
-	dispatchUpdateSnackbar,
-	comingSoonAdminbarToggle
-} from '../../util/helpers';
 
 const ComingSoonSection = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/home/settingsSection.js
+++ b/src/app/pages/home/settingsSection.js
@@ -1,3 +1,4 @@
+import { Heading } from '../../components';
 import graphicUrl from '../../../../assets/svg/a-illustration__checklist.svg';
 import {
 	Button,
@@ -5,8 +6,7 @@ import {
 	CardBody,
 	CardHeader,
 	CardFooter,
-	Dashicon,
-	__experimentalHeading as Heading,
+	Dashicon
 } from '@wordpress/components';
 import { Icon, settings, store } from '@wordpress/icons';
 

--- a/src/app/pages/home/stylesheet.scss
+++ b/src/app/pages/home/stylesheet.scss
@@ -39,6 +39,7 @@
 }
 
 .hgwp-section-card {
+    position: relative;
     z-index: 1;
 
     @media screen and (min-width: 882px) {

--- a/src/app/pages/home/webContentSection.js
+++ b/src/app/pages/home/webContentSection.js
@@ -1,3 +1,4 @@
+import { Heading } from '../../components';
 import graphicUrl from '../../../../assets/svg/a-illustration__gator-scales-image-3_-notext.svg';
 import {
 	Button,
@@ -5,8 +6,7 @@ import {
 	CardBody,
 	CardHeader,
 	CardFooter,
-	Dashicon,
-	__experimentalHeading as Heading,
+	Dashicon
 } from '@wordpress/components';
 
 const WebContentSection = () => {

--- a/src/app/pages/home/webHostingSection.js
+++ b/src/app/pages/home/webHostingSection.js
@@ -1,3 +1,4 @@
+import { Heading } from '../../components';
 import graphicUrl from '../../../../assets/svg/a-illustration__testenvironment.svg';
 import {
 	Button,
@@ -5,8 +6,7 @@ import {
 	CardBody,
 	CardHeader,
 	CardFooter,
-	Dashicon,
-	__experimentalHeading as Heading,
+	Dashicon
 } from '@wordpress/components';
 
 const WebHostingSection = () => {

--- a/src/app/pages/marketplace/plugins.js
+++ b/src/app/pages/marketplace/plugins.js
@@ -1,5 +1,4 @@
-import { __experimentalHeading as Heading } from '@wordpress/components';
-import MarketplaceItem from '../../components/marketplaceItem';
+import { Heading, MarketplaceItem } from '../../components';
 import plugins from '../../data/plugins';
 
 const Plugins = () => {

--- a/src/app/pages/marketplace/services.js
+++ b/src/app/pages/marketplace/services.js
@@ -1,5 +1,4 @@
-import { __experimentalHeading as Heading } from '@wordpress/components';
-import MarketplaceItem from '../../components/marketplaceItem';
+import { Heading, MarketplaceItem } from '../../components';
 import services from '../../data/services';
 
 const Services = () => {

--- a/src/app/pages/marketplace/stylesheet.scss
+++ b/src/app/pages/marketplace/stylesheet.scss
@@ -23,6 +23,8 @@
     border-color: var(--hgbrand-color-secondary);
 
     .components-tab-panel__tabs {
+        display: flex; /* <= WP 5.4 */
+        flex-direction: column; /* <= WP 5.6 */
         min-width: 10rem;
         margin-right: 2rem;
         margin-top: -1px;

--- a/src/app/pages/marketplace/themes.js
+++ b/src/app/pages/marketplace/themes.js
@@ -1,5 +1,4 @@
-import { __experimentalHeading as Heading } from '@wordpress/components';
-import MarketplaceItem from '../../components/marketplaceItem';
+import { Heading, MarketplaceItem } from '../../components';
 import themes from '../../data/themes';
 
 const Themes = () => {

--- a/src/app/pages/performance/cacheSettings.js
+++ b/src/app/pages/performance/cacheSettings.js
@@ -1,18 +1,17 @@
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	RadioControl,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { useUpdateEffect } from 'react-use';
 import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
+import { Heading, ErrorCard } from '../../components';
 import {
 	hostgatorSettingsApiFetch,
 	dispatchUpdateSnackbar,
 } from '../../util/helpers';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	RadioControl
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useUpdateEffect } from 'react-use';
 
 const CacheSettings = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/performance/clearCache.js
+++ b/src/app/pages/performance/clearCache.js
@@ -1,17 +1,16 @@
+import AppStore from '../../data/store';
+import { Heading, ErrorCard } from '../../components';
+import {
+	hostgatorPurgeCacheApiFetch,
+	dispatchUpdateSnackbar,
+} from '../../util/helpers';
 import {
 	Button,
 	Card,
 	CardBody,
 	CardHeader,
-	CardFooter,
-	__experimentalHeading as Heading,
+	CardFooter
 } from '@wordpress/components';
-import ErrorCard from '../../components/errorCard';
-import AppStore from '../../data/store';
-import {
-	hostgatorPurgeCacheApiFetch,
-	dispatchUpdateSnackbar,
-} from '../../util/helpers';
 
 const ClearCache = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/performance/settingsCallout.js
+++ b/src/app/pages/performance/settingsCallout.js
@@ -1,10 +1,10 @@
+import { Heading } from '../../components';
 import {
 	Card,
 	CardBody,
 	CardHeader,
     CardFooter,
-    Button,
-	__experimentalHeading as Heading,
+    Button
 } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 

--- a/src/app/pages/performance/stylesheet.scss
+++ b/src/app/pages/performance/stylesheet.scss
@@ -1,28 +1,65 @@
-.components-radio-control__option label span {
-    
-    strong {
-        font-size: 16px;
-        padding-top: 1px;
-    }
-     
-    span {
-        display: block;
-        opacity: 0.75;
-        padding: 0.5rem 0 0.25rem 1.75rem;
-        transition: .2s opacity ease;
-    }
+.hgwpp {
 
-    em {
-        display: block;
-        opacity: 0.6;
-        padding: 0 0 0.75rem 1.75rem;
-        transition: .2s opacity ease;
-    }
+    .components-radio-control__option label span {
+        
+        strong {
+            font-size: 16px;
+            padding-top: 1px;
+        }
+        
+        span {
+            display: block;
+            opacity: 0.75;
+            padding: 0.5rem 0 0.25rem 1.75rem;
+            transition: .2s opacity ease;
+        }
 
-    &:hover {
-        span,
         em {
-            opacity: 1;
+            display: block;
+            opacity: 0.6;
+            padding: 0 0 0.75rem 1.75rem;
+            transition: .2s opacity ease;
+        }
+
+        &:hover {
+            span,
+            em {
+                opacity: 1;
+            }
+        }
+
+    }
+
+    /* WP 5.5 || WP 5.6 */
+    [class*="hgwp-wp-5.5"],
+    [class*="hgwp-wp-5.6"] {
+        .components-radio-control__input[type="radio"]:checked::before {
+            margin-top: 5px;
+            margin-left: 5px;
+
+            @media screen and (min-width: 782px) {
+                height: 4px;
+                margin-top: 2px;
+                margin-left: 2px;
+                width: 4px;
+            }
+            
+        }
+    }
+
+    /* WP 5.7 */
+    [class*="hgwp-wp-5.7"] {
+        .components-radio-control__input[type="radio"]:checked::before {
+            height: 6px;
+            transform: translate(4px, 4px);
+            width: 6px;
+
+            @media screen and (min-width: 600px) {
+                height: 4px;
+                transform: translate(3px, 3px);
+                width: 4px;
+            }
+            
         }
     }
 }

--- a/src/app/pages/settings/automaticUpdates.js
+++ b/src/app/pages/settings/automaticUpdates.js
@@ -1,20 +1,19 @@
+import AppStore from '../../data/store';
+import { Heading, ErrorCard } from '../../components';
+import {
+	hostgatorSettingsApiFetch,
+	dispatchUpdateSnackbar,
+} from '../../util/helpers';
 import {
 	Card,
 	CardBody,
 	CardHeader,
 	CardDivider,
-	ToggleControl,
-	__experimentalHeading as Heading,
+	ToggleControl
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useEffect } from 'react';
 import { useUpdateEffect } from 'react-use';
-import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
-import {
-	hostgatorSettingsApiFetch,
-	dispatchUpdateSnackbar,
-} from '../../util/helpers';
 
 const AutomaticUpdates = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/settings/comingSoon.js
+++ b/src/app/pages/settings/comingSoon.js
@@ -1,21 +1,19 @@
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	CardDivider,
-	ToggleControl,
-	__experimentalHeading as Heading
-} from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { useUpdateEffect } from 'react-use';
 import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
+import { Heading, ErrorCard, Accordion } from '../../components';
 import {
 	hostgatorSettingsApiFetch,
 	dispatchUpdateSnackbar,
 	comingSoonAdminbarToggle
 } from '../../util/helpers';
-import Accordion from '../../components/accordion';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	CardDivider,
+	ToggleControl
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useUpdateEffect } from 'react-use';
 
 const ComingSoon = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/settings/commentSettings.js
+++ b/src/app/pages/settings/commentSettings.js
@@ -1,3 +1,9 @@
+import AppStore from '../../data/store';
+import { Heading, ErrorCard } from '../../components';
+import {
+	hostgatorSettingsApiFetch,
+	dispatchUpdateSnackbar,
+} from '../../util/helpers';
 import { _n } from '@wordpress/i18n';
 import {
 	Card,
@@ -5,17 +11,10 @@ import {
 	CardHeader,
 	CardDivider,
 	ToggleControl,
-	SelectControl,
-	__experimentalHeading as Heading,
+	SelectControl
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useUpdateEffect } from 'react-use';
-import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
-import {
-	hostgatorSettingsApiFetch,
-	dispatchUpdateSnackbar,
-} from '../../util/helpers';
 
 const CommentSettings = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/settings/contentSettings.js
+++ b/src/app/pages/settings/contentSettings.js
@@ -1,18 +1,17 @@
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	SelectControl,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
-import { useState } from '@wordpress/element';
-import { useUpdateEffect } from 'react-use';
 import AppStore from '../../data/store';
-import ErrorCard from '../../components/errorCard';
+import { Heading, ErrorCard } from '../../components';
 import {
 	hostgatorSettingsApiFetch,
 	dispatchUpdateSnackbar,
 } from '../../util/helpers';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	SelectControl
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useUpdateEffect } from 'react-use';
 
 const ContentSettings = () => {
 	const { store, setStore } = useContext(AppStore);

--- a/src/app/pages/settings/performanceCallout.js
+++ b/src/app/pages/settings/performanceCallout.js
@@ -1,11 +1,11 @@
+import { Heading } from '../../components';
 import {
 	Card,
 	CardBody,
 	CardHeader,
     CardFooter,
 	Dashicon,
-    Button,
-	__experimentalHeading as Heading,
+    Button
 } from '@wordpress/components';
 
 const PerformanceCallout = () => {

--- a/src/app/stylesheet.scss
+++ b/src/app/stylesheet.scss
@@ -82,9 +82,40 @@ body.toplevel_page_hostgator {
     .components-button {
         font-weight: 800;
         font-size: 15px;
+        transition: all 0.25s ease;
+        white-space: nowrap;
+
+        .dashicons, .dashicons-before:before {
+            transition: all .25s ease;
+        }
 
         &:focus:not(:disabled) {
             box-shadow: var(--hgbrand-focus);
+        }
+
+        &.is-primary,
+        &[variant="primary"] {
+            background-color: var(--hgbrand-color-primary);
+            color: var(--hgbrand-color-white);
+        }
+
+        &.is-secondary,
+        &[variant="secondary"] {
+            border-color: var(--hgbrand-color-primary);
+            box-shadow: inset 0 0 0 1px var(--hgbrand-color-primary);
+            color: var(--hgbrand-color-primary);
+        }
+
+        &:last-child {
+            padding-right: 1rem; /* <= WP 5.8 */
+        }
+
+        &.has-icon {
+            padding-right: 1rem;
+
+            .dashicon {
+                margin-right: 10px; /* <= WP 5.6 */
+            }
         }
     }
     a:focus {
@@ -94,6 +125,7 @@ body.toplevel_page_hostgator {
     .components-base-control__help,
     .components-radio-control__option label span span {
         color: var(--hgbrand-color-foreground-dark);
+        margin-top: 0.25rem;
     }
 }
 .hgwpp, .hgwpp * {
@@ -110,9 +142,6 @@ body.toplevel_page_hostgator {
     }
 }
 
-.components-button.has-icon {
-    padding-right: 1rem;
-}
 .components-snackbar__content {
     color: var(--hgbrand-color-background) !important;
 }
@@ -164,21 +193,24 @@ body.toplevel_page_hostgator {
     z-index: -1;
 }
 
+.hgwpp {
 
-.components-card {
-    
-    &.short {
-        margin-bottom: auto;
+    .components-card {
+        
+        &.short {
+            margin-bottom: auto;
+        }
+
+        &.disabled {
+            opacity: .5;
+        }
     }
 
-    &.disabled {
-        opacity: .5;
-    }
-}
+    .components-card-body,
+    .components-card__body {
 
-.components-card-body {
-
-    &.disabled {
-        opacity: .5;
+        &.disabled {
+            opacity: .5;
+        }
     }
 }

--- a/src/app/stylesheet.scss
+++ b/src/app/stylesheet.scss
@@ -55,6 +55,12 @@ body.toplevel_page_hostgator {
             width: 0;
         }
     }
+        
+    #wpbody-content .notice,
+    #wpbody-content .update-nag {
+        display: none;
+    }
+
 }
 .hgwpp {
     color: #363636;


### PR DESCRIPTION
This updates the plugin to work in WordPress versions 5.4.x, 5.5.x, 5.6.x, 5.7.x and fixes a couple of style issues in 5.8.x.

Notably adding a new component and using it in place of __experimentalHeading and cleaning up the component import statements.

It also adds an update prompt card to the admin app pages on <= 5.3.x. The app doesn't render in versions that low, but this at least renders something and prompts the user in the direction to fix it.

Fixes issues: 
#20 
#19 
#18 
#17 
#16
#15 
#14 
