### PR TITLE
add the dolly id to the notices that are hidden on our admin app page

### DIFF
--- a/src/app/stylesheet.scss
+++ b/src/app/stylesheet.scss
@@ -57,6 +57,7 @@ body.toplevel_page_hostgator {
     }
         
     #wpbody-content .notice,
+    #wpbody-content #dolly,
     #wpbody-content .update-nag {
         display: none;
     }


### PR DESCRIPTION
This hides the hello dolly lyrics on our app page. Need to port this over to web (and potentially bluehost) as well.