### PR TITLE
Add the SSO module to the HostGator plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "newfold-labs/wp-module-data": "^2.0",
         "newfold-labs/wp-module-loader": "^1.0",
         "newfold-labs/wp-module-marketplace": "^1.2",
+        "newfold-labs/wp-module-sso": "^1.0",
         "wp-forge/wp-update-handler": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73eae254b25790fc9f2c45111bbf8746",
+    "content-hash": "fabc79779dd8c9296272f1d545c99653",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -303,6 +303,48 @@
                 "issues": "https://github.com/newfold-labs/wp-module-marketplace/issues"
             },
             "time": "2022-09-02T16:22:35+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-sso",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-sso.git",
+                "reference": "ce753f809939971b1d3437c6545309680a59327f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-sso/zipball/ce753f809939971b1d3437c6545309680a59327f",
+                "reference": "ce753f809939971b1d3437c6545309680a59327f",
+                "shasum": ""
+            },
+            "require": {
+                "newfold-labs/wp-module-data": ">=2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewFoldLabs\\WP\\Module\\SSO\\": "includes"
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@bluehost.com"
+                }
+            ],
+            "description": "Single sign-on functionality for Newfold WordPress sites.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-sso/tree/1.0.3",
+                "issues": "https://github.com/newfold-labs/wp-module-sso/issues"
+            },
+            "time": "2022-07-15T18:33:14+00:00"
         },
         {
             "name": "wp-forge/fluent",


### PR DESCRIPTION
Currently, the HostGator plugin doesn't contain the SSO module. This PR adds it.