### PR TITLE
Fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "newfold-labs/wp-module-data": "^2.4.3",
         "newfold-labs/wp-module-loader": "^1.0.10",
         "newfold-labs/wp-module-marketplace": "^2.0.0-beta.2",
-        "newfold-labs/wp-module-notifications": "^1.1.3",
+        "newfold-labs/wp-module-notifications": "^1.1.4",
         "newfold-labs/wp-module-runtime": "^1.0.2",
         "newfold-labs/wp-module-secure-passwords": "^1.1",
         "newfold-labs/wp-module-sso": "^1.0.4",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "newfold-labs/wp-module-coming-soon": "^1.1.8",
         "newfold-labs/wp-module-data": "^2.4.3",
         "newfold-labs/wp-module-loader": "^1.0.10",
-        "newfold-labs/wp-module-marketplace": "^2.0.0-beta.2",
+        "newfold-labs/wp-module-marketplace": "^2.0.0",
         "newfold-labs/wp-module-notifications": "^1.1.4",
         "newfold-labs/wp-module-runtime": "^1.0.2",
         "newfold-labs/wp-module-secure-passwords": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62653b19d799e83e6d7b1e98f6e87cdf",
+    "content-hash": "670ccb0ec21dfb1e3e0f574ceaf7adc4",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -318,16 +318,16 @@
         },
         {
             "name": "newfold-labs/wp-module-notifications",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-notifications.git",
-                "reference": "9dd736f5d5bbdd7d1f16f959bb698d75d9e56166"
+                "reference": "16e25bcd0eae302baeb4db84e502ae2fea018d17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-notifications/zipball/9dd736f5d5bbdd7d1f16f959bb698d75d9e56166",
-                "reference": "9dd736f5d5bbdd7d1f16f959bb698d75d9e56166",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-notifications/zipball/16e25bcd0eae302baeb4db84e502ae2fea018d17",
+                "reference": "16e25bcd0eae302baeb4db84e502ae2fea018d17",
                 "shasum": ""
             },
             "require": {
@@ -356,10 +356,10 @@
             ],
             "description": "A module for managing Newfold in-site notifications.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-notifications/tree/1.1.3",
+                "source": "https://github.com/newfold-labs/wp-module-notifications/tree/1.1.4",
                 "issues": "https://github.com/newfold-labs/wp-module-notifications/issues"
             },
-            "time": "2023-08-14T20:34:43+00:00"
+            "time": "2023-08-24T20:04:45+00:00"
         },
         {
             "name": "newfold-labs/wp-module-runtime",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "670ccb0ec21dfb1e3e0f574ceaf7adc4",
+    "content-hash": "4bf727ebbfec2f4472536f2c4a2d37bc",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -261,16 +261,16 @@
         },
         {
             "name": "newfold-labs/wp-module-marketplace",
-            "version": "2.0.0-beta.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-marketplace.git",
-                "reference": "019f4ebae77211722c987675410f5e14cc7b96e7"
+                "reference": "5498c1659ca50eb382d460bfc4402830d5569390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-marketplace/zipball/019f4ebae77211722c987675410f5e14cc7b96e7",
-                "reference": "019f4ebae77211722c987675410f5e14cc7b96e7",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-marketplace/zipball/5498c1659ca50eb382d460bfc4402830d5569390",
+                "reference": "5498c1659ca50eb382d460bfc4402830d5569390",
                 "shasum": ""
             },
             "require": {
@@ -311,10 +311,10 @@
             ],
             "description": "A module for rendering product data and interacting with the Hiive marketplace API.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-marketplace/tree/2.0.0-beta.2",
+                "source": "https://github.com/newfold-labs/wp-module-marketplace/tree/2.0.0",
                 "issues": "https://github.com/newfold-labs/wp-module-marketplace/issues"
             },
-            "time": "2023-08-23T22:40:15+00:00"
+            "time": "2023-08-24T20:23:41+00:00"
         },
         {
             "name": "newfold-labs/wp-module-notifications",
@@ -2040,9 +2040,7 @@
         }
     ],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "newfold-labs/wp-module-marketplace": 10
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -43,5 +43,8 @@ module.exports = defineConfig({
     ],
     supportFile: 'tests/cypress/support/index.js',
     testIsolation: false,
+		excludeSpecPattern: [
+      'vendor/newfold-labs/wp-module-coming-soon/tests/cypress/integration/coming-soon.cy.{js,jsx,ts,tsx}', // omit until ecommerce module is added
+		],
   },
 })

--- a/src/app/stylesheet.scss
+++ b/src/app/stylesheet.scss
@@ -162,6 +162,10 @@ body.toplevel_page_hostgator {
         color: var(--color-text);
         margin-top: 0.25rem;
     }
+
+    .newfold-notifications-wrapper .notice {
+        display: block !important;
+    }
 }
 
 .hgwpp,


### PR DESCRIPTION
- [x] Coming Soon
- [x] Marketplace
- [x] Notifications


### Use local coming soon tests and exclude the module-based test for coming soon
once the ecommerce module is included we can use module-based tests because the ecommerce module affects the coming soon notices and placements ideally we make the coming soon module independent from the ecommerce module.

### Update Marketplace module with brand-agnostic tests

### Update Notifications module with multi-brand tests