### PR TITLE
Update Onboarding to 1.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "newfold-labs/wp-module-loader": "^1.0.10",
         "newfold-labs/wp-module-marketplace": "^2.0.2",
         "newfold-labs/wp-module-notifications": "^1.1.5",
-        "newfold-labs/wp-module-onboarding": "^1.10.4",
+        "newfold-labs/wp-module-onboarding": "^1.11.0",
         "newfold-labs/wp-module-performance": "^1.2.1",
         "newfold-labs/wp-module-runtime": "^1.0.5",
         "newfold-labs/wp-module-secure-passwords": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "newfold-labs/wp-module-loader": "^1.0.10",
         "newfold-labs/wp-module-marketplace": "^2.0.2",
         "newfold-labs/wp-module-notifications": "^1.1.5",
-        "newfold-labs/wp-module-onboarding": "^1.11.0",
+        "newfold-labs/wp-module-onboarding": "^1.11.1",
         "newfold-labs/wp-module-performance": "^1.2.1",
         "newfold-labs/wp-module-runtime": "^1.0.5",
         "newfold-labs/wp-module-secure-passwords": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43a0d4b63b69fd1b8069c2d421a45440",
+    "content-hash": "52c006161d185a948e65419bbacc56b2",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -513,27 +513,27 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "1.10.4",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "639c8164cabba7760a01391107a9c14831932562"
+                "reference": "be6a011d78660058fbeb1d43192cd92ff8fde8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/639c8164cabba7760a01391107a9c14831932562",
-                "reference": "639c8164cabba7760a01391107a9c14831932562",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/be6a011d78660058fbeb1d43192cd92ff8fde8c9",
+                "reference": "be6a011d78660058fbeb1d43192cd92ff8fde8c9",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14",
-                "newfold-labs/wp-module-installer": "^1.1",
+                "newfold-labs/wp-module-onboarding-data": "^0.0.2",
                 "newfold-labs/wp-module-patterns": "^0.1.2",
-                "wp-cli/wp-config-transformer": "^1.3",
-                "wp-forge/wp-upgrade-handler": "^1.0"
+                "wp-cli/wp-config-transformer": "^1.3"
             },
             "require-dev": {
                 "newfold-labs/wp-php-standards": "^1.2",
+                "wp-cli/i18n-command": "^2.4.3",
                 "wp-phpunit/wp-phpunit": "^6.2",
                 "yoast/phpunit-polyfills": "^2.0"
             },
@@ -565,10 +565,51 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.10.4",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.11.0",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2023-09-20T12:11:19+00:00"
+            "time": "2023-09-28T08:56:05+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-onboarding-data",
+            "version": "0.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
+                "reference": "d0c6c03d24c6b15e8516007146ac226a4af14449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/d0c6c03d24c6b15e8516007146ac226a4af14449",
+                "reference": "d0c6c03d24c6b15e8516007146ac226a4af14449",
+                "shasum": ""
+            },
+            "require": {
+                "newfold-labs/wp-module-data": "^2.4.3",
+                "newfold-labs/wp-module-installer": "^1.1",
+                "wp-forge/wp-upgrade-handler": "^1.0"
+            },
+            "require-dev": {
+                "newfold-labs/wp-php-standards": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\Onboarding\\Data\\": "includes/"
+                }
+            },
+            "authors": [
+                {
+                    "name": "arunshenoy99",
+                    "email": "devarunshenoy99@gmail.com"
+                }
+            ],
+            "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/0.0.2",
+                "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
+            },
+            "time": "2023-09-28T08:43:53+00:00"
         },
         {
             "name": "newfold-labs/wp-module-patterns",
@@ -2392,5 +2433,5 @@
     "platform-overrides": {
         "php": "7.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52c006161d185a948e65419bbacc56b2",
+    "content-hash": "554dad51228823ac3638c2918314cfe7",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -513,16 +513,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "be6a011d78660058fbeb1d43192cd92ff8fde8c9"
+                "reference": "3f653d59646b3d1a2e07d26bf2b8179b4c568d82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/be6a011d78660058fbeb1d43192cd92ff8fde8c9",
-                "reference": "be6a011d78660058fbeb1d43192cd92ff8fde8c9",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/3f653d59646b3d1a2e07d26bf2b8179b4c568d82",
+                "reference": "3f653d59646b3d1a2e07d26bf2b8179b4c568d82",
                 "shasum": ""
             },
             "require": {
@@ -565,10 +565,10 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.11.0",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.11.1",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2023-09-28T08:56:05+00:00"
+            "time": "2023-09-29T09:38:33+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
@@ -2433,5 +2433,5 @@
     "platform-overrides": {
         "php": "7.0.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
https://github.com/newfold-labs/wp-module-data/pull/36 will also have to go with this.

Changes:

- Added Migrate Button to Start Setup
- Tracking Site Features on Step Change
- Updated `pt_BR` translations
- Disabled Chapter Prioritization 
- Added Onboarding Data Module
- Skiped Flaky Tests
- Fixed 404 Bugs
- Added a Release Workflow