### PR TITLE
use helper method to look up links and help content based on region

### DIFF
--- a/src/app/components/site-info/index.js
+++ b/src/app/components/site-info/index.js
@@ -2,7 +2,7 @@ import { LockClosedIcon, LockOpenIcon } from "@heroicons/react/24/outline";
 import { NewfoldRuntime } from "@newfold-labs/wp-module-runtime";
 import { Button } from "@newfold/ui-component-library";
 import { HostgatorIcon, WordPressIcon } from "../icons";
-import { addUtmParams } from "../../util/helpers";
+import { getLinkPerRegion } from '../../util/helpers';
 
 export const SiteInfoBar = () => {
     const { url, title } = NewfoldRuntime.siteDetails;
@@ -37,7 +37,7 @@ export const SiteInfoBar = () => {
                 <div className="nfd-w-max nfd-flex nfd-items-center nfd-flex-wrap nfd-gap-3">
                     <Button 
                         as="a"
-                        href={addUtmParams( 'https://portal.hostgator.com/login' )}
+                        href={ getLinkPerRegion( 'site_info_portal', __("HostGator Account", "wp-plugin-hostgator") ) }
                         target="_blank"
                         variant="primary" 
                         className="nfd-bg-primary-400 nfd-text-tiny nfd-w-full min-[400px]:nfd-w-auto">

--- a/src/app/data/help.js
+++ b/src/app/data/help.js
@@ -8,6 +8,7 @@ const help = [
 		),
 		icon: false,
 		cta: __('Call Us', 'wp-plugin-hostgator'),
+		id: 'help_phone_number',
 		url: 'tel:18669642867',
 	},
 	{
@@ -19,6 +20,7 @@ const help = [
 		),
 		icon: false,
 		cta: __('Live Chat', 'wp-plugin-hostgator'),
+		id: 'help_chat',
 		url: 'https://helpchat.hostgator.com/?utm_campaign=&utm_content=help_chat_link&utm_term=live_chat&utm_medium=brand_plugin&utm_source=wp-admin/admin.php?page=hostgator#/help'
 	},
 	{
@@ -30,6 +32,7 @@ const help = [
 		),
 		icon: false,
 		cta: __('Tweet Us', 'wp-plugin-hostgator'),
+		id: 'help_twitter',
 		url: 'https://twitter.com/hgsupport',
 	},
 	{
@@ -38,6 +41,7 @@ const help = [
 		description: __('Know what the pros know.', 'wp-plugin-hostgator'),
 		icon: false,
 		cta: __('Find Answers', 'wp-plugin-hostgator'),
+		id: 'help_kb',
 		url: 'https://www.hostgator.com/help?utm_campaign=&utm_content=help_kb_link&utm_term=find_answers&utm_medium=brand_plugin&utm_source=wp-admin/admin.php?page=hostgator#/help',
 	},
 	{
@@ -49,6 +53,7 @@ const help = [
 		),
 		icon: false,
 		cta: __('Learn Stuff', 'wp-plugin-hostgator'),
+		id: 'help_blog',
 		url: 'https://www.hostgator.com/blog/?utm_campaign=&utm_content=help_blog_link&utm_term=learn_stuff&utm_medium=brand_plugin&utm_source=wp-admin/admin.php?page=hostgator#/help',
 	},
 	{
@@ -60,6 +65,7 @@ const help = [
 		),
 		icon: false,
 		cta: __('Watch Now', 'wp-plugin-hostgator'),
+		id: 'help_youtube',
 		url: 'https://www.youtube.com/c/hostgatorUS',
 	},
 ];

--- a/src/app/data/region.js
+++ b/src/app/data/region.js
@@ -25,6 +25,13 @@ const region = {
         CL: 'https://www.hostgator.cl',
         CO: 'https://www.hostgator.co',
     },
+    site_info_portal: {
+        default: 'https://portal.hostgator.com/login',
+        BR: 'https://financeiro.hostgator.com.br/',
+        MX: 'https://cliente.hostgator.mx',
+        CL: 'https://cliente.hostgator.cl',
+        CO: 'https://cliente.hostgator.co',
+    },
     home_manage_sites: {
         default: 'https://portal.hostgator.com/packages',
         BR: 'https://cliente.hostgator.com.br/',
@@ -49,23 +56,23 @@ const region = {
     help_phone_number: {
         default: 'tel:8669642867',
         BR: 'false', // a string false value will remove this section
-        MX: 'false', // a string false value will remove this section
-        CL: 'false', // a string false value will remove this section
-        CO: 'false', // a string false value will remove this section
+        MX: 'false',
+        CL: 'false',
+        CO: 'false',
     },
     help_chat: {
         default: 'https://helpchat.hostgator.com/',
-        BR: 'https://financeiro.hostgator.com.br/chat/?country=br&department=technical', // ideally to be open in a popup, not new tab
+        BR: 'https://suporte.hostgator.com.br/',
         MX: 'https://billing.hostgator.mx/chat/?country=mx&department=technical',
         CL: 'https://billing.hostgator.mx/chat/?country=cl&department=technical',
         CO: 'https://billing.hostgator.mx/chat/?country=co&department=technical',
     },
     help_twitter: {
         default: 'https://twitter.com/hgsupport',
-        BR: 'https://twitter.com/hostgatorbrasil',
-        MX: 'https://twitter.com/HostGatorES',
-        CL: 'https://twitter.com/HostGatorES',
-        CO: 'https://twitter.com/HostGatorES',
+        BR: 'false', // a string false value will remove this section
+        MX: 'false',
+        CL: 'false',
+        CO: 'false',
     },
     help_kb: {
         default: 'https://www.hostgator.com/help',
@@ -83,7 +90,7 @@ const region = {
     },
     help_youtube: {
         default: 'https://www.youtube.com/c/hostgatorUS',
-        BR: 'https://www.youtube.com/c/HostGatorBrasil',
+        BR: 'https://www.youtube.com/user/HostGatorBRTV',
         MX: 'https://www.youtube.com/c/HostGatorM%C3%A9xico',
         CL: 'https://www.youtube.com/c/HostGatorM%C3%A9xico',
         CO: 'https://www.youtube.com/c/HostGatorM%C3%A9xico',

--- a/src/app/pages/help/index.js
+++ b/src/app/pages/help/index.js
@@ -1,6 +1,7 @@
 import { Page } from '../../components/page';
 import { SectionContainer, SectionContent, SectionHeader } from '../../components/section';
 import help from '../../data/help';
+import { getLinkPerRegion, supportsLinkPerRegion } from '../../util/helpers';
 import { Button, Card, Title } from "@newfold/ui-component-library";
 
 const HelpCard = ({ item }) => {
@@ -20,7 +21,7 @@ const HelpCard = ({ item }) => {
 					variant="secondary"
 					as="a"
 					className="nfd-w-full"
-					href={item.url}
+					href={ getLinkPerRegion( item.id, item.cta )}
 					target="_blank"
 				>
 					{item.cta}
@@ -37,6 +38,7 @@ const Help = () => {
 		return (
 			<div className="nfd-grid nfd-gap-6 nfd-grid-cols-1 sm:nfd-grid-cols-2 xl:nfd-grid-cols-3 2xl:nfd-grid-cols-4">
 				{helpItems.map((item) => (
+					supportsLinkPerRegion(item.id) &&
 					<HelpCard key={item.name} item={item} />
 				))}
 			</div>


### PR DESCRIPTION
This goes back to using our helper method to look up links and help card content based on regional settings in a big region config object. The existing URL property is ignored in the help data object and we use id to reference the region config object key.

This was in place to some extent earlier but was lost due to the UI update. This adds back the lookup and updates values as designated in https://jira.newfold.com/browse/PRESS1-186

Now the site info button should update based on region as well as the help section display and links based on region. Links have also been updated for BR region.