### PR TITLE
update ecommerce module to 1.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "doctrine/inflector": "1.2.0 as 1.3.1",
         "newfold-labs/wp-module-coming-soon": "^1.1.9",
         "newfold-labs/wp-module-data": "^2.4.8",
-        "newfold-labs/wp-module-ecommerce": "^1.2.6",
+        "newfold-labs/wp-module-ecommerce": "^1.3.2",
         "newfold-labs/wp-module-loader": "^1.0.10",
         "newfold-labs/wp-module-marketplace": "^2.0.2",
         "newfold-labs/wp-module-notifications": "^1.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "184f961e0597ec6713094919e9f31cc4",
+    "content-hash": "633dfb866e8de3769cc48bf2789a6458",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -265,20 +265,21 @@
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",
-            "version": "v1.2.6",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ecommerce.git",
-                "reference": "6bf5b8e15586c555a8cc47f1aa342dc39069fa23"
+                "reference": "4064e8760bd4b39cce73ce317a9eba72718f4bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/6bf5b8e15586c555a8cc47f1aa342dc39069fa23",
-                "reference": "6bf5b8e15586c555a8cc47f1aa342dc39069fa23",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/4064e8760bd4b39cce73ce317a9eba72718f4bf6",
+                "reference": "4064e8760bd4b39cce73ce317a9eba72718f4bf6",
                 "shasum": ""
             },
             "require": {
-                "newfold-labs/wp-module-installer": "^1.1"
+                "newfold-labs/wp-module-installer": "^1.1",
+                "newfold-labs/wp-module-onboarding-data": "^0.0"
             },
             "require-dev": {
                 "newfold-labs/wp-php-standards": "@stable",
@@ -316,10 +317,10 @@
             ],
             "description": "Brand Agnostic eCommerce Experience",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.2.6",
+                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.2",
                 "issues": "https://github.com/newfold-labs/wp-module-ecommerce/issues"
             },
-            "time": "2023-09-27T13:12:33+00:00"
+            "time": "2023-10-12T15:03:50+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",


### PR DESCRIPTION
This updates the ecommerce module to version 1.3.2.

Main goal is to get this into the plugin: https://github.com/newfold-labs/wp-module-ecommerce/pull/152

Also includes all of: https://github.com/newfold-labs/wp-module-ecommerce/compare/v1.2.6...v1.3.2