### PR TITLE
Update/region case insensitive

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,7 +38,7 @@ $nfd_module_container->set(
 					'id'           => 'hostgator',
 					'file'         => HOSTGATOR_PLUGIN_FILE,
 					'brand'        => get_option( 'mm_brand', 'hostgator' ),
-					'region'       => get_option( 'hg_region', 'US' ),
+					'region'       => strtoupper( get_option( 'hg_region', 'US' ) ),
 					'install_date' => get_option( 'hg_plugin_install_date', false ),
 				)
 			);
@@ -50,7 +50,7 @@ $nfd_module_container->set(
 if ( get_option( 'mm_brand', false ) && get_option( 'hg_region', false ) ) {
 	$nfd_module_container->set(
 		'marketplace_brand',
-		get_option( 'mm_brand', false ) . '_' . get_option( 'hg_region', false )
+		get_option( 'mm_brand', false ) . '_' . strtoupper( get_option( 'hg_region', false ) )
 	);
 }
 

--- a/src/app/util/helpers.js
+++ b/src/app/util/helpers.js
@@ -151,16 +151,15 @@ export const getRegionValue = () => {
 	// qualify region setting and return region code
 	switch ( region ) {
 		case 'BR':
-			return region;
-			break;
 		case 'MX':
 		case 'CO':
 		case 'CL':
 			return region;
 			break;
+		case 'US':
 		case false:
 		default:
-			return '';
+			return 'default';
 	}
 };
 

--- a/src/app/util/helpers.js
+++ b/src/app/util/helpers.js
@@ -142,7 +142,7 @@ export const comingSoonAdminbarToggle = ( comingSoon ) => {
  */
 export const getRegionValue = () => {
 	const brand  = NewfoldRuntime.sdk.plugin.brand;
-	const region = NewfoldRuntime.sdk.plugin.region;
+	const region =  NewfoldRuntime.sdk.plugin.region.toUpperCase();
 
 	// bail if not hostgator-latam brand
 	if ( brand !== 'hostgator-latam' ){


### PR DESCRIPTION
This will always ensure the `hg_region` value is UPPERCASE. Sounds like the installer has set it to lowercase in the past. This should allow those to still work for regional specific content and links.

We're setting it in the container, when it sets marketplace region override and in the helper js that adjusts content based on region.