### PR TITLE
Add/ab login redirect

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -147,6 +147,7 @@ require HOSTGATOR_PLUGIN_DIR . '/inc/Admin.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/AdminBar.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/base.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/jetpack.php';
+require HOSTGATOR_PLUGIN_DIR . '/inc/LoginRedirect.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/partners.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/RestApi/CachingController.php';
 require HOSTGATOR_PLUGIN_DIR . '/inc/RestApi/SettingsController.php';

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace HostGator;
+
+/**
+ * Class LoginRedirect
+ *
+ * @package HostGatorWordPressPlugin
+ */
+class LoginRedirect {
+
+	/**
+	 * Initialize the login redirect functionality.
+	 */
+	public static function init() {
+		add_action( 'login_redirect', array( __CLASS__, 'on_login_redirect' ), 10, 3 );
+		add_action( 'login_init', array( __CLASS__, 'on_login_init' ), 10, 3 );
+        add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
+		add_filter( 'login_form_defaults', array( __CLASS__, 'filter_login_form_defaults' ) );
+		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
+	}
+
+	/**
+	 * Get default redirect URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public static function get_default_redirect_url( $url ) {
+		return current_user_can( 'manage_options' ) ? self::get_bluehost_dashboard_url() : $url;
+	}
+
+	/**
+	 * Set the $_REQUEST['redirect_to'] value on the login_init action since there isn't a better way to do it before
+	 * WordPress automatically defaults it to the WordPress dashboard URL.
+	 */
+	public static function on_login_init() {
+		if ( ! isset( $_REQUEST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_REQUEST['redirect_to'] = self::get_bluehost_dashboard_url();
+		}
+	}
+
+	/**
+	 * Set default redirect used in the wp_login_form() function.
+	 *
+	 * @param array $defaults Collection of existing defaults.
+	 *
+	 * @return array
+	 */
+	public static function filter_login_form_defaults( array $defaults ) {
+		$defaults['redirect'] = self::get_bluehost_dashboard_url();
+
+		return $defaults;
+	}
+
+	/**
+	 * Customize the login redirect URL if one hasn't already been set.
+	 *
+	 * @param string   $redirect_to           Current redirect URL.
+	 * @param string   $requested_redirect_to Requested redirect URL.
+	 * @param \WP_User $user                  WordPress user.
+	 *
+	 * @return string
+	 */
+	public static function on_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
+
+		if ( self::is_user( $user ) ) {
+			// If no redirect is defined and the user is an administrator, redirect to the Bluehost dashboard.
+			if ( (empty( $requested_redirect_to ) || admin_url( '/' ) === $requested_redirect_to ) && self::is_administrator( $user ) ) {
+				return self::get_bluehost_dashboard_url();
+			}
+
+			// If the user isn't an admin and the redirect is to the Bluehost dashboard, point them to the WP dashboard instead.
+			if ( ! self::is_administrator( $user ) && self::is_bluehost_redirect( $requested_redirect_to ) ) {
+				return admin_url( '/' );
+			}
+		}
+
+		return $redirect_to;
+	}
+
+    /**
+     * Disable Yoast onboarding redirect.
+     */
+    public static function disable_yoast_onboarding_redirect() {
+        if ( class_exists( 'WPSEO_Options' ) ) {
+			\WPSEO_Options::set( 'should_redirect_after_install_free', false );
+		}
+    }
+
+	/**
+	 * Check if we have a valid user.
+	 *
+	 * @param \WP_User $user The WordPress user object.
+	 *
+	 * @return bool
+	 */
+	public static function is_user( $user ) {
+		return $user && is_object( $user ) && is_a( $user, 'WP_User' );
+	}
+
+	/**
+	 * Check if a user is an administrator.
+	 *
+	 * @param \WP_User $user WordPress user.
+	 *
+	 * @return bool
+	 */
+	public static function is_administrator( $user ) {
+		return self::is_user( $user ) && $user->has_cap( 'manage_options' );
+	}
+
+	/**
+	 * Check if the current redirect is to the Bluehost plugin.
+	 *
+	 * @param string $redirect The current redirect URL.
+	 *
+	 * @return bool
+	 */
+	public static function is_bluehost_redirect( $redirect ) {
+		return false !== strpos( $redirect, admin_url( 'admin.php?page=bluehost' ) );
+	}
+
+	/**
+	 * Get the Bluehost dashboard URL.
+	 *
+	 * @return string
+	 */
+	public static function get_bluehost_dashboard_url() {
+		return admin_url( 'admin.php?page=bluehost#/home' );
+	}
+
+}
+
+LoginRedirect::init();

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -20,6 +20,17 @@ class LoginRedirect {
 		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
 	}
 
+    /**
+     * Check if we should redirect.
+     * Redirect only if abTestPluginHome capability is true
+     * 
+     * @return boolean
+     */
+    public static function should_redirect() {
+        global $nfd_module_container;
+        return $nfd_module_container->get( 'capabilities' )->get('abTestPluginHome');
+    }
+
 	/**
 	 * Get default redirect URL.
 	 *

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -119,9 +119,8 @@ class LoginRedirect {
 	 * @return bool
 	 */
 	public static function is_plugin_redirect( $redirect ) {
-		global $nfd_module_container;
-        $plugin_id = $nfd_module_container->plugin()->id;
-		return false !== strpos( $redirect, admin_url( 'admin.php?page={$plugin_id}' ) );
+        $plugin_id = self::get_plugin_id();
+		return false !== strpos( $redirect, admin_url( 'admin.php?page=' . $plugin_id ) );
 	}
 
 	/**
@@ -130,9 +129,18 @@ class LoginRedirect {
 	 * @return string
 	 */
 	public static function get_plugin_dashboard_url() {
+		$plugin_id = self::get_plugin_id();
+		return admin_url( 'admin.php?page=' . $plugin_id . '#/home' );
+	}
+
+	/**
+	 * Get the Plugin dashboard URL.
+	 *
+	 * @return string
+	 */
+	public static function get_plugin_id() {
 		global $nfd_module_container;
-        $plugin_id = $nfd_module_container->plugin()->id;
-		return admin_url( 'admin.php?page={$plugin_id}#/home' );
+        return $nfd_module_container->plugin()->id;
 	}
 
 }

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -47,7 +47,7 @@ class LoginRedirect {
 	 * WordPress automatically defaults it to the WordPress dashboard URL.
 	 */
 	public static function on_login_init() {
-		if ( ! isset( $_REQUEST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_REQUEST['redirect_to'] ) && self::should_redirect() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$_REQUEST['redirect_to'] = self::get_plugin_dashboard_url();
 		}
 	}
@@ -60,8 +60,10 @@ class LoginRedirect {
 	 * @return array
 	 */
 	public static function filter_login_form_defaults( array $defaults ) {
-		$defaults['redirect'] = self::get_plugin_dashboard_url();
-
+        if ( self::should_redirect() ) {
+		    $defaults['redirect'] = self::get_plugin_dashboard_url();
+        }
+        
 		return $defaults;
 	}
 
@@ -76,7 +78,7 @@ class LoginRedirect {
 	 */
 	public static function on_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
 
-		if ( self::is_user( $user ) ) {
+		if ( self::is_user( $user ) && self::should_redirect() ) {
 			// If no redirect is defined and the user is an administrator, redirect to the Plugin dashboard.
 			if ( (empty( $requested_redirect_to ) || admin_url( '/' ) === $requested_redirect_to ) && self::is_administrator( $user ) ) {
 				return self::get_plugin_dashboard_url();
@@ -95,7 +97,7 @@ class LoginRedirect {
      * Disable Yoast onboarding redirect.
      */
     public static function disable_yoast_onboarding_redirect() {
-        if ( class_exists( 'WPSEO_Options' ) ) {
+        if ( class_exists( 'WPSEO_Options' ) && self::should_redirect() ) {
 			\WPSEO_Options::set( 'should_redirect_after_install_free', false );
 		}
     }

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -5,7 +5,7 @@ namespace HostGator;
 /**
  * Class LoginRedirect
  *
- * @package HostGatorWordPressPlugin
+ * @package HostHostGatorWordPressPluginGator
  */
 class LoginRedirect {
 
@@ -28,7 +28,7 @@ class LoginRedirect {
 	 * @return string
 	 */
 	public static function get_default_redirect_url( $url ) {
-		return current_user_can( 'manage_options' ) ? self::get_bluehost_dashboard_url() : $url;
+		return current_user_can( 'manage_options' ) ? self::get_plugin_dashboard_url() : $url;
 	}
 
 	/**
@@ -37,7 +37,7 @@ class LoginRedirect {
 	 */
 	public static function on_login_init() {
 		if ( ! isset( $_REQUEST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$_REQUEST['redirect_to'] = self::get_bluehost_dashboard_url();
+			$_REQUEST['redirect_to'] = self::get_plugin_dashboard_url();
 		}
 	}
 
@@ -49,7 +49,7 @@ class LoginRedirect {
 	 * @return array
 	 */
 	public static function filter_login_form_defaults( array $defaults ) {
-		$defaults['redirect'] = self::get_bluehost_dashboard_url();
+		$defaults['redirect'] = self::get_plugin_dashboard_url();
 
 		return $defaults;
 	}
@@ -66,13 +66,13 @@ class LoginRedirect {
 	public static function on_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
 
 		if ( self::is_user( $user ) ) {
-			// If no redirect is defined and the user is an administrator, redirect to the Bluehost dashboard.
+			// If no redirect is defined and the user is an administrator, redirect to the Plugin dashboard.
 			if ( (empty( $requested_redirect_to ) || admin_url( '/' ) === $requested_redirect_to ) && self::is_administrator( $user ) ) {
-				return self::get_bluehost_dashboard_url();
+				return self::get_plugin_dashboard_url();
 			}
 
-			// If the user isn't an admin and the redirect is to the Bluehost dashboard, point them to the WP dashboard instead.
-			if ( ! self::is_administrator( $user ) && self::is_bluehost_redirect( $requested_redirect_to ) ) {
+			// If the user isn't an admin and the redirect is to the Plugin dashboard, point them to the WP dashboard instead.
+			if ( ! self::is_administrator( $user ) && self::is_plugin_redirect( $requested_redirect_to ) ) {
 				return admin_url( '/' );
 			}
 		}
@@ -112,23 +112,27 @@ class LoginRedirect {
 	}
 
 	/**
-	 * Check if the current redirect is to the Bluehost plugin.
+	 * Check if the current redirect is to the Plugin plugin.
 	 *
 	 * @param string $redirect The current redirect URL.
 	 *
 	 * @return bool
 	 */
-	public static function is_bluehost_redirect( $redirect ) {
-		return false !== strpos( $redirect, admin_url( 'admin.php?page=bluehost' ) );
+	public static function is_plugin_redirect( $redirect ) {
+		global $nfd_module_container;
+        $plugin_id = $nfd_module_container->plugin()->id;
+		return false !== strpos( $redirect, admin_url( 'admin.php?page={$plugin_id}' ) );
 	}
 
 	/**
-	 * Get the Bluehost dashboard URL.
+	 * Get the Plugin dashboard URL.
 	 *
 	 * @return string
 	 */
-	public static function get_bluehost_dashboard_url() {
-		return admin_url( 'admin.php?page=bluehost#/home' );
+	public static function get_plugin_dashboard_url() {
+		global $nfd_module_container;
+        $plugin_id = $nfd_module_container->plugin()->id;
+		return admin_url( 'admin.php?page={$plugin_id}#/home' );
 	}
 
 }


### PR DESCRIPTION
A PR to single out the login redirect stuff we talked about getting into this release today in case it needs its own discussion/testing.

This adds a LoginRedirect class from BH (https://github.com/bluehost/bluehost-wordpress-plugin/blob/main/inc/LoginRedirect.php) and updates it to be compatible with all brands/plugins.

Also updates the class to include a should_redirect method which checks an ab capability value. To test this we can set this value locally via a filter:

`
add_filter(
    'pre_transient_nfd_site_capabilities',
    function () {
       return [
          "abTestPluginHome" => true
       ];
    }
);
`

Suggestions/improvements are welcome, but as we're trying to release this very soon, minor iterations can come later as long as this is functional and secure.