### PR TITLE
Fix SSO Redirect Issue

### DIFF
--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -15,21 +15,22 @@ class LoginRedirect {
 	public static function init() {
 		add_action( 'login_redirect', array( __CLASS__, 'on_login_redirect' ), 10, 3 );
 		add_action( 'login_init', array( __CLASS__, 'on_login_init' ), 10, 3 );
-        add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
+		add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
 		add_filter( 'login_form_defaults', array( __CLASS__, 'filter_login_form_defaults' ) );
 		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
 	}
 
-    /**
-     * Check if we should redirect.
-     * Redirect only if abTestPluginHome capability is true
-     * 
-     * @return boolean
-     */
-    public static function should_redirect() {
-        global $nfd_module_container;
-        return $nfd_module_container->get( 'capabilities' )->get('abTestPluginHome');
-    }
+	/**
+	 * Check if we should redirect.
+	 * Redirect only if abTestPluginHome capability is true
+	 *
+	 * @return boolean
+	 */
+	public static function should_redirect() {
+		global $nfd_module_container;
+
+		return $nfd_module_container->get( 'capabilities' )->get( 'abTestPluginHome' );
+	}
 
 	/**
 	 * Get default redirect URL.
@@ -60,19 +61,19 @@ class LoginRedirect {
 	 * @return array
 	 */
 	public static function filter_login_form_defaults( array $defaults ) {
-        if ( self::should_redirect() ) {
-		    $defaults['redirect'] = self::get_plugin_dashboard_url();
-        }
-        
+		if ( self::should_redirect() ) {
+			$defaults['redirect'] = self::get_plugin_dashboard_url();
+		}
+
 		return $defaults;
 	}
 
 	/**
 	 * Customize the login redirect URL if one hasn't already been set.
 	 *
-	 * @param string   $redirect_to           Current redirect URL.
-	 * @param string   $requested_redirect_to Requested redirect URL.
-	 * @param \WP_User $user                  WordPress user.
+	 * @param string $redirect_to Current redirect URL.
+	 * @param string $requested_redirect_to Requested redirect URL.
+	 * @param \WP_User $user WordPress user.
 	 *
 	 * @return string
 	 */
@@ -80,7 +81,7 @@ class LoginRedirect {
 
 		if ( self::is_user( $user ) && self::should_redirect() ) {
 			// If no redirect is defined and the user is an administrator, redirect to the Plugin dashboard.
-			if ( (empty( $requested_redirect_to ) || admin_url( '/' ) === $requested_redirect_to ) && self::is_administrator( $user ) ) {
+			if ( ( empty( $requested_redirect_to ) || admin_url( '/' ) === $requested_redirect_to ) && self::is_administrator( $user ) ) {
 				return self::get_plugin_dashboard_url();
 			}
 
@@ -93,14 +94,14 @@ class LoginRedirect {
 		return $redirect_to;
 	}
 
-    /**
-     * Disable Yoast onboarding redirect.
-     */
-    public static function disable_yoast_onboarding_redirect() {
-        if ( class_exists( 'WPSEO_Options' ) && self::should_redirect() ) {
+	/**
+	 * Disable Yoast onboarding redirect.
+	 */
+	public static function disable_yoast_onboarding_redirect() {
+		if ( class_exists( 'WPSEO_Options' ) && self::should_redirect() ) {
 			\WPSEO_Options::set( 'should_redirect_after_install_free', false );
 		}
-    }
+	}
 
 	/**
 	 * Check if we have a valid user.
@@ -132,7 +133,8 @@ class LoginRedirect {
 	 * @return bool
 	 */
 	public static function is_plugin_redirect( $redirect ) {
-        $plugin_id = self::get_plugin_id();
+		$plugin_id = self::get_plugin_id();
+
 		return false !== strpos( $redirect, admin_url( 'admin.php?page=' . $plugin_id ) );
 	}
 
@@ -143,6 +145,7 @@ class LoginRedirect {
 	 */
 	public static function get_plugin_dashboard_url() {
 		$plugin_id = self::get_plugin_id();
+
 		return admin_url( 'admin.php?page=' . $plugin_id . '#/home' );
 	}
 
@@ -153,7 +156,8 @@ class LoginRedirect {
 	 */
 	public static function get_plugin_id() {
 		global $nfd_module_container;
-        return $nfd_module_container->plugin()->id;
+
+		return $nfd_module_container->plugin()->id;
 	}
 
 }

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -10,12 +10,22 @@ namespace HostGator;
 class LoginRedirect {
 
 	/**
+	 * @var \NewfoldLabs\WP\ModuleLoader\Container
+	 */
+	public static $container;
+
+	/**
 	 * Initialize the login redirect functionality.
 	 */
 	public static function init() {
+
+		global $nfd_module_container;
+		self::$container = $nfd_module_container;
+
 		add_action( 'login_redirect', array( __CLASS__, 'on_login_redirect' ), 10, 3 );
 		add_action( 'login_init', array( __CLASS__, 'on_login_init' ), 10, 3 );
 		add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
+
 		add_filter( 'login_form_defaults', array( __CLASS__, 'filter_login_form_defaults' ) );
 		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
 	}
@@ -27,9 +37,7 @@ class LoginRedirect {
 	 * @return boolean
 	 */
 	public static function should_redirect() {
-		global $nfd_module_container;
-
-		return $nfd_module_container->get( 'capabilities' )->get( 'abTestPluginHome' );
+		return current_user_can( 'manage_options' ) && self::$container->get( 'capabilities' )->get( 'abTestPluginHome' );
 	}
 
 	/**
@@ -40,7 +48,7 @@ class LoginRedirect {
 	 * @return string
 	 */
 	public static function get_default_redirect_url( $url ) {
-		return current_user_can( 'manage_options' ) ? self::get_plugin_dashboard_url() : $url;
+		return self::should_redirect() ? self::get_plugin_dashboard_url() : $url;
 	}
 
 	/**
@@ -155,9 +163,7 @@ class LoginRedirect {
 	 * @return string
 	 */
 	public static function get_plugin_id() {
-		global $nfd_module_container;
-
-		return $nfd_module_container->plugin()->id;
+		return self::$container->plugin()->id;
 	}
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1712,9 +1712,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
-            "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
+            "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
@@ -4506,9 +4506,9 @@
             "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
         },
         "node_modules/@types/semver": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-            "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
             "dev": true
         },
         "node_modules/@types/send": {
@@ -4673,16 +4673,16 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
-            "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
+            "integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/type-utils": "6.11.0",
-                "@typescript-eslint/utils": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/type-utils": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -4708,15 +4708,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
-            "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
+            "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/typescript-estree": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4736,13 +4736,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
-            "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
+            "integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0"
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -4753,13 +4753,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
-            "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
+            "integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.11.0",
-                "@typescript-eslint/utils": "6.11.0",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -4780,9 +4780,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
-            "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
+            "integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -4793,13 +4793,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
-            "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
+            "integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4820,17 +4820,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
-            "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
+            "integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/typescript-estree": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -4845,12 +4845,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
-            "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
+            "integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.11.0",
+                "@typescript-eslint/types": "6.13.1",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -5142,9 +5142,9 @@
             }
         },
         "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.29.0.tgz",
-            "integrity": "sha512-VPAn1iVZae1sQ6QaiMKbp3AzFPbhBl6YQeDr3AKpj24GTiUmsho6WgxijzyhBEBX5xPHVCahhQ8mjiZ5Ql6FwA==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.30.0.tgz",
+            "integrity": "sha512-UKkyFmEYk1UTO0ZPun6Kw5dNflTEDpDK/6RxAqxbVrsIWUVSkVahwBnqfS0v5LuvVU8y+5vJSR/WjlnKEmS3Sg==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -5154,9 +5154,9 @@
             }
         },
         "node_modules/@wordpress/babel-preset-default": {
-            "version": "7.30.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.30.0.tgz",
-            "integrity": "sha512-O/IA8Jvh6MzlTyeo0As2chhZ2w6WdvMYSjjTDDC66SkbnUxUf4jWqehncHGrtQLoQJfwsCUnyWSH4ePb/j+kIw==",
+            "version": "7.31.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.31.0.tgz",
+            "integrity": "sha512-LAiTOlolFvKW6xmL6qRkdbPG09LPwAsmDepz4zWrFXJZHSImDeO2QXHecF1GnFyzLLKr1myHR5MbN3K5MSzpqQ==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.16.0",
@@ -5165,9 +5165,9 @@
                 "@babel/preset-env": "^7.16.0",
                 "@babel/preset-typescript": "^7.16.0",
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/babel-plugin-import-jsx-pragma": "^4.29.0",
-                "@wordpress/browserslist-config": "^5.29.0",
-                "@wordpress/warning": "^2.46.0",
+                "@wordpress/babel-plugin-import-jsx-pragma": "^4.30.0",
+                "@wordpress/browserslist-config": "^5.30.0",
+                "@wordpress/warning": "^2.47.0",
                 "browserslist": "^4.21.10",
                 "core-js": "^3.31.0",
                 "react": "^18.2.0"
@@ -5177,15 +5177,15 @@
             }
         },
         "node_modules/@wordpress/base-styles": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.37.0.tgz",
-            "integrity": "sha512-HxYlZHHpq0XDd+/ixTjB0g2smw8NIhal0gZgKJsQSPra/TN5Swjt0e3QwW3MBGZKWhV9poNmsBGNZonVCe9bSA==",
+            "version": "4.38.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.38.0.tgz",
+            "integrity": "sha512-w491MMHfoCHdWibyTAcmGWvXwNMptslFQOU+jQ5DVeDIgDux1KLo/7oZ41CCHwqYayrCf60BC9+JopDXqq1H+g==",
             "dev": true
         },
         "node_modules/@wordpress/browserslist-config": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.29.0.tgz",
-            "integrity": "sha512-sVDgPWcI3wdKd3cIvgf/NLO7HtEkwyV4bWuSztzoemNMGQW17BhH2Blx46HnJFXm9ooYw4SpAOyioHTkuT+JFg==",
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.30.0.tgz",
+            "integrity": "sha512-HFgLCkvvxba+j7/qNjVn1od38tvMm1xVlIJBR+zukkTvvLu/AkdelWKAQpvAoFAXMaZJ7239VxDVBYbVolf6FQ==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -5560,9 +5560,9 @@
             }
         },
         "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.29.0.tgz",
-            "integrity": "sha512-cYvTkjDvxpZSEjM1RRNciK/7W+RXC+qXXzbdRyGhkE0AzIspA7UAV3NoEyjtbL2V2wNJmBmsZKJf0wuYandDQA==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.30.0.tgz",
+            "integrity": "sha512-Z3AcceaoHFvJdRNVp8rf6EI+rxK0gUMGMfcXYZPAoaDhP6Gt0bsbVMP5zQH2EYl7JHsbRZIQmMqd2fG5E/VjSQ==",
             "dev": true,
             "dependencies": {
                 "json2php": "^0.0.7",
@@ -5605,14 +5605,14 @@
             }
         },
         "node_modules/@wordpress/e2e-test-utils-playwright": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.14.0.tgz",
-            "integrity": "sha512-aeH6HhI67lfUTZ1miMhI/xq61JDd5yMFMN5wH24e1/1w7SItXZtCz306tht5h4HeqFeS6xzRwA8j6lM7PNdWQg==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.15.0.tgz",
+            "integrity": "sha512-ZqCYcxT0Gc59isS42Q7WTQVu3ace8DDEED/RR8loTG+YjqEB1pW5hALFiVXBtM6vSjnnDO0M1NYAldh8l7SCmA==",
             "dev": true,
             "dependencies": {
-                "@wordpress/api-fetch": "^6.43.0",
-                "@wordpress/keycodes": "^3.46.0",
-                "@wordpress/url": "^3.47.0",
+                "@wordpress/api-fetch": "^6.44.0",
+                "@wordpress/keycodes": "^3.47.0",
+                "@wordpress/url": "^3.48.0",
                 "change-case": "^4.1.2",
                 "form-data": "^4.0.0",
                 "get-port": "^5.1.1",
@@ -5628,27 +5628,27 @@
             }
         },
         "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/@wordpress/api-fetch": {
-            "version": "6.43.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.43.0.tgz",
-            "integrity": "sha512-DYtawNaOHDxgIl+B/E1oU+VMhFJJfy/oYR5e7+PFUX0t0yHhHuH8XaWKpZvpvo0Y/GOuJ2NkDcJDqSZXD2TFYw==",
+            "version": "6.44.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.44.0.tgz",
+            "integrity": "sha512-d8ouvBiKDFu67O9Y8MtlUR2YojCAjmLf0LuBKsSOS5r3MOiwte1tQwsLdzFmGYkdCK09mZhT3UVKdOOiAC3kKA==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.46.0",
-                "@wordpress/url": "^3.47.0"
+                "@wordpress/i18n": "^4.47.0",
+                "@wordpress/url": "^3.48.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/@wordpress/keycodes": {
-            "version": "3.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.46.0.tgz",
-            "integrity": "sha512-08ubCD321T85BZBUQuco2/vwIC5Pfzbw4CY7E2xR3rGzX3vb7SjDbKIqKeJL/UfYSmZF9GY+KaspSa1ywFtWiA==",
+            "version": "3.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.47.0.tgz",
+            "integrity": "sha512-dmYpqCWUoCM290YA5ApES9nqz/0D1JngIlZtel+BvELf8fj/jctdsT5wDB7dVdvZCuyr5SF+1Od00DYbMbb5oA==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.46.0",
+                "@wordpress/i18n": "^4.47.0",
                 "change-case": "^4.1.2"
             },
             "engines": {
@@ -5656,9 +5656,9 @@
             }
         },
         "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/@wordpress/url": {
-            "version": "3.47.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.47.0.tgz",
-            "integrity": "sha512-eDj7eDDYS8/UaUioulM54JkhmYvplvwW8+rbidR0fKZLr9zu3mfM7vrlwpIv9OK2RMenqEvu7Ij2gc5n/YEAcQ==",
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.48.0.tgz",
+            "integrity": "sha512-12bjIBBGcA5X8RPvUURLJZzpB60O5DI3WxQVIBBKPF4Mv8nUmgT4uemGzf5/ble8lqzJVntyEhEWKPOxEbUbJg==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
@@ -5727,16 +5727,16 @@
             }
         },
         "node_modules/@wordpress/eslint-plugin": {
-            "version": "17.3.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.3.0.tgz",
-            "integrity": "sha512-u6ZMf8sL4act3bNuX0CTuu9quCBw68BItpb5gpyo7LGmV4+/cic14GVWPBTroA9oz6z5UHjIfjKMqib7NGecWQ==",
+            "version": "17.4.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.4.0.tgz",
+            "integrity": "sha512-CT19Ib1Y0ttVQm/bOtjGP6Ge5eqfEaUSobTqCWreHt1RIoxJXTDmazJ1g0Q5MjqG4dEZ/Q/FI4sdqyiKRySkbQ==",
             "dev": true,
             "dependencies": {
                 "@babel/eslint-parser": "^7.16.0",
                 "@typescript-eslint/eslint-plugin": "^6.4.1",
                 "@typescript-eslint/parser": "^6.4.1",
-                "@wordpress/babel-preset-default": "^7.30.0",
-                "@wordpress/prettier-config": "^3.3.0",
+                "@wordpress/babel-preset-default": "^7.31.0",
+                "@wordpress/prettier-config": "^3.4.0",
                 "cosmiconfig": "^7.0.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-import": "^2.25.2",
@@ -5830,12 +5830,12 @@
             }
         },
         "node_modules/@wordpress/i18n": {
-            "version": "4.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.46.0.tgz",
-            "integrity": "sha512-5/61hd50KkqGgoQpf66DDft6sMTKfeGVdmZOt42GWymylxFSmbZLLnR8YafECQrmia/TdwIco5I4n0hIikYbNQ==",
+            "version": "4.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.47.0.tgz",
+            "integrity": "sha512-7qOeSChhI8drcnKAbpM2yP2HSWRR0U8xvww3Febd3kGhMKAUp8AMpjyC4rWucak4+Eg1HFfahurCmBt3FxgbYQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.46.0",
+                "@wordpress/hooks": "^3.47.0",
                 "gettext-parser": "^1.3.1",
                 "memize": "^2.1.0",
                 "sprintf-js": "^1.1.1",
@@ -5849,9 +5849,9 @@
             }
         },
         "node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-            "version": "3.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-            "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+            "version": "3.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+            "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
             "dependencies": {
                 "@babel/runtime": "^7.16.0"
             },
@@ -5886,9 +5886,9 @@
             }
         },
         "node_modules/@wordpress/jest-console": {
-            "version": "7.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.17.0.tgz",
-            "integrity": "sha512-i1r0fGEZforoB1C8QuSfDDYwMycAJ/MqkEvhqWNLwcJy/JFYGWiKhkzhKfQ7aMUuwtrEJMb+41AOxelT565bDw==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.18.0.tgz",
+            "integrity": "sha512-OjPGbU1HgjLVNCLW9ROmdkw/qhpFL6Svlfv1aUVBrq5z1nJ7SrjRMeBSq4LJloOhTasSV9z7w4mhHJkMkfolJg==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.0",
@@ -5902,12 +5902,12 @@
             }
         },
         "node_modules/@wordpress/jest-preset-default": {
-            "version": "11.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.17.0.tgz",
-            "integrity": "sha512-Z1KAr9ViDLFiVAYsRkyAAwLBzxu6MTv1dAZpHhyZhYfxTNdTOnnHbNGHpsfv5OlT5xHxptkrESLP8klU2/kw4A==",
+            "version": "11.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.18.0.tgz",
+            "integrity": "sha512-qwcDXfKkdBJnnsQAa0qkBsg94usGQCD914pWNeBg997qy/6zmVYVXpPjXoJXaC/lYbEIRAWGfry1RSiM6ZoC9g==",
             "dev": true,
             "dependencies": {
-                "@wordpress/jest-console": "^7.17.0",
+                "@wordpress/jest-console": "^7.18.0",
                 "babel-jest": "^29.6.2"
             },
             "engines": {
@@ -5946,9 +5946,9 @@
             }
         },
         "node_modules/@wordpress/npm-package-json-lint-config": {
-            "version": "4.31.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.31.0.tgz",
-            "integrity": "sha512-Y/MxST3sK/En6ZAChlyq5A7qtII9/1MLqk6o75yWPIDn1ew40V7iPBDkFKE3uMEPw1RW8rJ9WSQxNpcN+4k+Zg==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.32.0.tgz",
+            "integrity": "sha512-qyEnU9FoWpaa67pufu9fNmTCikiYhdKc4R01ffO+xX7wyJXMo0Z6EJog6ajU9E2+YL86AmAX+sO1CHuXcsxdbw==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -5958,12 +5958,12 @@
             }
         },
         "node_modules/@wordpress/postcss-plugins-preset": {
-            "version": "4.30.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.30.0.tgz",
-            "integrity": "sha512-b/APWKhvocBrs+IHJNe7BOfFmvyRmOZEHEXvwPZy2iGIC95tA5p2/7h3/iSwUGNUcyGObqwd90Htfit9oIdQJA==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.31.0.tgz",
+            "integrity": "sha512-B6bHsCKxt25nkvWfIJH3l7kENKS20mpsiRIl5+CEES6kKfBwg4IPx+JyA/RPLFQcIQNtIYFft22p5bgT4VZcEg==",
             "dev": true,
             "dependencies": {
-                "@wordpress/base-styles": "^4.37.0",
+                "@wordpress/base-styles": "^4.38.0",
                 "autoprefixer": "^10.2.5"
             },
             "engines": {
@@ -5974,9 +5974,9 @@
             }
         },
         "node_modules/@wordpress/prettier-config": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.3.0.tgz",
-            "integrity": "sha512-G0HoubSikorLtXs0CZ0TNGbhKImCr+Ztg0HQUKv683r+yiZBOQV1igk7TaHOmIaf6702Bt4E3++IoAQN8Nr5ew==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.4.0.tgz",
+            "integrity": "sha512-6qawlZqqbe6NDY0txzsPZThRFAXzf0a891wI/A4KNWVKUXQwTluXWMtGZx3xlFtvkX+9ZHdoqXbWysGQztiBOQ==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -6207,24 +6207,24 @@
             }
         },
         "node_modules/@wordpress/scripts": {
-            "version": "26.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.17.0.tgz",
-            "integrity": "sha512-DmnZphBSkp9cX5YVAh9PchBh45iSaPFyh9Ria8rlH9zp/O5KQ2eWte4xv84B5FbKzUIqilNdtLTPrvsm0PQiGg==",
+            "version": "26.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.18.0.tgz",
+            "integrity": "sha512-cL3CKlPbH+JOnkV4MtGFUDys3KNlp6tjwrGBcpXsYOEm55DYtdXNmkRXHIfiM5hxCWiuE0P0dR7o/6F3Nz3TGA==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.16.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
                 "@svgr/webpack": "^8.0.1",
-                "@wordpress/babel-preset-default": "^7.30.0",
-                "@wordpress/browserslist-config": "^5.29.0",
-                "@wordpress/dependency-extraction-webpack-plugin": "^4.29.0",
-                "@wordpress/e2e-test-utils-playwright": "^0.14.0",
-                "@wordpress/eslint-plugin": "^17.3.0",
-                "@wordpress/jest-preset-default": "^11.17.0",
-                "@wordpress/npm-package-json-lint-config": "^4.31.0",
-                "@wordpress/postcss-plugins-preset": "^4.30.0",
-                "@wordpress/prettier-config": "^3.3.0",
-                "@wordpress/stylelint-config": "^21.29.0",
+                "@wordpress/babel-preset-default": "^7.31.0",
+                "@wordpress/browserslist-config": "^5.30.0",
+                "@wordpress/dependency-extraction-webpack-plugin": "^4.30.0",
+                "@wordpress/e2e-test-utils-playwright": "^0.15.0",
+                "@wordpress/eslint-plugin": "^17.4.0",
+                "@wordpress/jest-preset-default": "^11.18.0",
+                "@wordpress/npm-package-json-lint-config": "^4.32.0",
+                "@wordpress/postcss-plugins-preset": "^4.31.0",
+                "@wordpress/prettier-config": "^3.4.0",
+                "@wordpress/stylelint-config": "^21.30.0",
                 "adm-zip": "^0.5.9",
                 "babel-jest": "^29.6.2",
                 "babel-loader": "^8.2.3",
@@ -6243,7 +6243,7 @@
                 "fast-glob": "^3.2.7",
                 "filenamify": "^4.2.0",
                 "jest": "^29.6.2",
-                "jest-dev-server": "^6.0.2",
+                "jest-dev-server": "^9.0.1",
                 "jest-environment-jsdom": "^29.6.2",
                 "jest-environment-node": "^29.6.2",
                 "markdownlint-cli": "^0.31.1",
@@ -6285,9 +6285,9 @@
             }
         },
         "node_modules/@wordpress/stylelint-config": {
-            "version": "21.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.29.0.tgz",
-            "integrity": "sha512-8VetLM5CTg8iLgodgpY4x132Yf4gPWMMffqfAG8HFwwvVQxm0mjl/dNtj6RBrxemdTi7dHr1jnZvqU+XxQlHXQ==",
+            "version": "21.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.30.0.tgz",
+            "integrity": "sha512-PlvXzYgjn7OUaVTy2bahSr6oL/eu1OdRWxrZfGVNxF4jRswND/ThqOEHIzxETNGTe0ggZOyY+40St4Swlo1zZQ==",
             "dev": true,
             "dependencies": {
                 "stylelint-config-recommended": "^6.0.0",
@@ -6336,9 +6336,9 @@
             }
         },
         "node_modules/@wordpress/warning": {
-            "version": "2.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.46.0.tgz",
-            "integrity": "sha512-oyUNmDz64nF8vnS9LaobXMIx6K5w+XhAtvo3Cjv3kCVIuWFwpxoeMus3pUo1A7v2H9zcW+E87zwEuqsLPYjNfQ==",
+            "version": "2.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.47.0.tgz",
+            "integrity": "sha512-lmpLNI8Si7HrSY0LBBtp7Z6NzAkh1y7yeJI0LZw17EsJ0MM5FSXqXJRrNY7L4tM8G/vv3OacUw1mRAZX7bzBRQ==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -7018,13 +7018,21 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "node_modules/axobject-query": {
             "version": "3.2.1",
@@ -7335,9 +7343,9 @@
             }
         },
         "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "dev": true,
             "engines": {
                 "node": ">=0.6"
@@ -8624,9 +8632,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-            "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+            "version": "3.33.3",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+            "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
             "dev": true,
             "hasInstallScript": true,
             "funding": {
@@ -14193,18 +14201,21 @@
             "dev": true
         },
         "node_modules/jest-dev-server": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.2.0.tgz",
-            "integrity": "sha512-ZWh8CuvxwjhYfvw4tGeftziqIvw/26R6AG3OTgNTQeXul8aZz48RQjDpnlDwnWX53jxJJl9fcigqIdSU5lYZuw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.1.tgz",
+            "integrity": "sha512-eqpJKSvVl4M0ojHZUPNbka8yEzLNbIMiINXDsuMF3lYfIdRO2iPqy+ASR4wBQ6nUyR3OT24oKPWhpsfLhgAVyg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.2",
                 "cwd": "^0.10.0",
                 "find-process": "^1.4.7",
                 "prompts": "^2.4.2",
-                "spawnd": "^6.2.0",
+                "spawnd": "^9.0.1",
                 "tree-kill": "^1.2.2",
-                "wait-on": "^6.0.1"
+                "wait-on": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/jest-diff": {
@@ -20438,14 +20449,28 @@
             }
         },
         "node_modules/spawnd": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.2.0.tgz",
-            "integrity": "sha512-qX/I4lQy4KgVEcNle0kuc4FxFWHISzBhZW1YemPfwmrmQjyZmfTK/OhBKkhrD2ooAaFZEm1maEBLE6/6enwt+g==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.1.tgz",
+            "integrity": "sha512-vaMk8E9CpbjTYToBxLXowDeArGf1+yI7A6PU6Nr57b2g8BVY8nRi5vTBj3bMF8UkCrMdTMyf/Lh+lrcrW2z7pw==",
             "dev": true,
             "dependencies": {
-                "exit": "^0.1.2",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.1.0",
                 "tree-kill": "^1.2.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/spawnd/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/spdx-correct": {
@@ -22257,22 +22282,22 @@
             }
         },
         "node_modules/wait-on": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
-            "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
             "dev": true,
             "dependencies": {
-                "axios": "^0.25.0",
-                "joi": "^17.6.0",
+                "axios": "^1.6.1",
+                "joi": "^17.11.0",
                 "lodash": "^4.17.21",
-                "minimist": "^1.2.5",
-                "rxjs": "^7.5.4"
+                "minimist": "^1.2.8",
+                "rxjs": "^7.8.1"
             },
             "bin": {
                 "wait-on": "bin/wait-on"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/wait-on/node_modules/rxjs": {
@@ -24276,9 +24301,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
-            "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
+            "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.22.15",
@@ -26479,9 +26504,9 @@
             "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
         },
         "@types/semver": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-            "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
             "dev": true
         },
         "@types/send": {
@@ -26644,16 +26669,16 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
-            "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
+            "integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/type-utils": "6.11.0",
-                "@typescript-eslint/utils": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/type-utils": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -26663,54 +26688,54 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
-            "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
+            "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/typescript-estree": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
-            "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
+            "integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0"
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
-            "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
+            "integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.11.0",
-                "@typescript-eslint/utils": "6.11.0",
+                "@typescript-eslint/typescript-estree": "6.13.1",
+                "@typescript-eslint/utils": "6.13.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
-            "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
+            "integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
-            "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
+            "integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/visitor-keys": "6.11.0",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/visitor-keys": "6.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -26719,27 +26744,27 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
-            "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
+            "integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.11.0",
-                "@typescript-eslint/types": "6.11.0",
-                "@typescript-eslint/typescript-estree": "6.11.0",
+                "@typescript-eslint/scope-manager": "6.13.1",
+                "@typescript-eslint/types": "6.13.1",
+                "@typescript-eslint/typescript-estree": "6.13.1",
                 "semver": "^7.5.4"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
-            "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
+            "integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.11.0",
+                "@typescript-eslint/types": "6.13.1",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "dependencies": {
@@ -26992,15 +27017,15 @@
             }
         },
         "@wordpress/babel-plugin-import-jsx-pragma": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.29.0.tgz",
-            "integrity": "sha512-VPAn1iVZae1sQ6QaiMKbp3AzFPbhBl6YQeDr3AKpj24GTiUmsho6WgxijzyhBEBX5xPHVCahhQ8mjiZ5Ql6FwA==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.30.0.tgz",
+            "integrity": "sha512-UKkyFmEYk1UTO0ZPun6Kw5dNflTEDpDK/6RxAqxbVrsIWUVSkVahwBnqfS0v5LuvVU8y+5vJSR/WjlnKEmS3Sg==",
             "dev": true
         },
         "@wordpress/babel-preset-default": {
-            "version": "7.30.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.30.0.tgz",
-            "integrity": "sha512-O/IA8Jvh6MzlTyeo0As2chhZ2w6WdvMYSjjTDDC66SkbnUxUf4jWqehncHGrtQLoQJfwsCUnyWSH4ePb/j+kIw==",
+            "version": "7.31.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.31.0.tgz",
+            "integrity": "sha512-LAiTOlolFvKW6xmL6qRkdbPG09LPwAsmDepz4zWrFXJZHSImDeO2QXHecF1GnFyzLLKr1myHR5MbN3K5MSzpqQ==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.16.0",
@@ -27009,24 +27034,24 @@
                 "@babel/preset-env": "^7.16.0",
                 "@babel/preset-typescript": "^7.16.0",
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/babel-plugin-import-jsx-pragma": "^4.29.0",
-                "@wordpress/browserslist-config": "^5.29.0",
-                "@wordpress/warning": "^2.46.0",
+                "@wordpress/babel-plugin-import-jsx-pragma": "^4.30.0",
+                "@wordpress/browserslist-config": "^5.30.0",
+                "@wordpress/warning": "^2.47.0",
                 "browserslist": "^4.21.10",
                 "core-js": "^3.31.0",
                 "react": "^18.2.0"
             }
         },
         "@wordpress/base-styles": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.37.0.tgz",
-            "integrity": "sha512-HxYlZHHpq0XDd+/ixTjB0g2smw8NIhal0gZgKJsQSPra/TN5Swjt0e3QwW3MBGZKWhV9poNmsBGNZonVCe9bSA==",
+            "version": "4.38.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.38.0.tgz",
+            "integrity": "sha512-w491MMHfoCHdWibyTAcmGWvXwNMptslFQOU+jQ5DVeDIgDux1KLo/7oZ41CCHwqYayrCf60BC9+JopDXqq1H+g==",
             "dev": true
         },
         "@wordpress/browserslist-config": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.29.0.tgz",
-            "integrity": "sha512-sVDgPWcI3wdKd3cIvgf/NLO7HtEkwyV4bWuSztzoemNMGQW17BhH2Blx46HnJFXm9ooYw4SpAOyioHTkuT+JFg==",
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.30.0.tgz",
+            "integrity": "sha512-HFgLCkvvxba+j7/qNjVn1od38tvMm1xVlIJBR+zukkTvvLu/AkdelWKAQpvAoFAXMaZJ7239VxDVBYbVolf6FQ==",
             "dev": true
         },
         "@wordpress/components": {
@@ -27350,9 +27375,9 @@
             }
         },
         "@wordpress/dependency-extraction-webpack-plugin": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.29.0.tgz",
-            "integrity": "sha512-cYvTkjDvxpZSEjM1RRNciK/7W+RXC+qXXzbdRyGhkE0AzIspA7UAV3NoEyjtbL2V2wNJmBmsZKJf0wuYandDQA==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.30.0.tgz",
+            "integrity": "sha512-Z3AcceaoHFvJdRNVp8rf6EI+rxK0gUMGMfcXYZPAoaDhP6Gt0bsbVMP5zQH2EYl7JHsbRZIQmMqd2fG5E/VjSQ==",
             "dev": true,
             "requires": {
                 "json2php": "^0.0.7",
@@ -27386,14 +27411,14 @@
             }
         },
         "@wordpress/e2e-test-utils-playwright": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.14.0.tgz",
-            "integrity": "sha512-aeH6HhI67lfUTZ1miMhI/xq61JDd5yMFMN5wH24e1/1w7SItXZtCz306tht5h4HeqFeS6xzRwA8j6lM7PNdWQg==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.15.0.tgz",
+            "integrity": "sha512-ZqCYcxT0Gc59isS42Q7WTQVu3ace8DDEED/RR8loTG+YjqEB1pW5hALFiVXBtM6vSjnnDO0M1NYAldh8l7SCmA==",
             "dev": true,
             "requires": {
-                "@wordpress/api-fetch": "^6.43.0",
-                "@wordpress/keycodes": "^3.46.0",
-                "@wordpress/url": "^3.47.0",
+                "@wordpress/api-fetch": "^6.44.0",
+                "@wordpress/keycodes": "^3.47.0",
+                "@wordpress/url": "^3.48.0",
                 "change-case": "^4.1.2",
                 "form-data": "^4.0.0",
                 "get-port": "^5.1.1",
@@ -27403,31 +27428,31 @@
             },
             "dependencies": {
                 "@wordpress/api-fetch": {
-                    "version": "6.43.0",
-                    "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.43.0.tgz",
-                    "integrity": "sha512-DYtawNaOHDxgIl+B/E1oU+VMhFJJfy/oYR5e7+PFUX0t0yHhHuH8XaWKpZvpvo0Y/GOuJ2NkDcJDqSZXD2TFYw==",
+                    "version": "6.44.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.44.0.tgz",
+                    "integrity": "sha512-d8ouvBiKDFu67O9Y8MtlUR2YojCAjmLf0LuBKsSOS5r3MOiwte1tQwsLdzFmGYkdCK09mZhT3UVKdOOiAC3kKA==",
                     "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.16.0",
-                        "@wordpress/i18n": "^4.46.0",
-                        "@wordpress/url": "^3.47.0"
+                        "@wordpress/i18n": "^4.47.0",
+                        "@wordpress/url": "^3.48.0"
                     }
                 },
                 "@wordpress/keycodes": {
-                    "version": "3.46.0",
-                    "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.46.0.tgz",
-                    "integrity": "sha512-08ubCD321T85BZBUQuco2/vwIC5Pfzbw4CY7E2xR3rGzX3vb7SjDbKIqKeJL/UfYSmZF9GY+KaspSa1ywFtWiA==",
+                    "version": "3.47.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.47.0.tgz",
+                    "integrity": "sha512-dmYpqCWUoCM290YA5ApES9nqz/0D1JngIlZtel+BvELf8fj/jctdsT5wDB7dVdvZCuyr5SF+1Od00DYbMbb5oA==",
                     "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.16.0",
-                        "@wordpress/i18n": "^4.46.0",
+                        "@wordpress/i18n": "^4.47.0",
                         "change-case": "^4.1.2"
                     }
                 },
                 "@wordpress/url": {
-                    "version": "3.47.0",
-                    "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.47.0.tgz",
-                    "integrity": "sha512-eDj7eDDYS8/UaUioulM54JkhmYvplvwW8+rbidR0fKZLr9zu3mfM7vrlwpIv9OK2RMenqEvu7Ij2gc5n/YEAcQ==",
+                    "version": "3.48.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.48.0.tgz",
+                    "integrity": "sha512-12bjIBBGcA5X8RPvUURLJZzpB60O5DI3WxQVIBBKPF4Mv8nUmgT4uemGzf5/ble8lqzJVntyEhEWKPOxEbUbJg==",
                     "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.16.0",
@@ -27486,16 +27511,16 @@
             }
         },
         "@wordpress/eslint-plugin": {
-            "version": "17.3.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.3.0.tgz",
-            "integrity": "sha512-u6ZMf8sL4act3bNuX0CTuu9quCBw68BItpb5gpyo7LGmV4+/cic14GVWPBTroA9oz6z5UHjIfjKMqib7NGecWQ==",
+            "version": "17.4.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.4.0.tgz",
+            "integrity": "sha512-CT19Ib1Y0ttVQm/bOtjGP6Ge5eqfEaUSobTqCWreHt1RIoxJXTDmazJ1g0Q5MjqG4dEZ/Q/FI4sdqyiKRySkbQ==",
             "dev": true,
             "requires": {
                 "@babel/eslint-parser": "^7.16.0",
                 "@typescript-eslint/eslint-plugin": "^6.4.1",
                 "@typescript-eslint/parser": "^6.4.1",
-                "@wordpress/babel-preset-default": "^7.30.0",
-                "@wordpress/prettier-config": "^3.3.0",
+                "@wordpress/babel-preset-default": "^7.31.0",
+                "@wordpress/prettier-config": "^3.4.0",
                 "cosmiconfig": "^7.0.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-import": "^2.25.2",
@@ -27555,12 +27580,12 @@
             }
         },
         "@wordpress/i18n": {
-            "version": "4.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.46.0.tgz",
-            "integrity": "sha512-5/61hd50KkqGgoQpf66DDft6sMTKfeGVdmZOt42GWymylxFSmbZLLnR8YafECQrmia/TdwIco5I4n0hIikYbNQ==",
+            "version": "4.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.47.0.tgz",
+            "integrity": "sha512-7qOeSChhI8drcnKAbpM2yP2HSWRR0U8xvww3Febd3kGhMKAUp8AMpjyC4rWucak4+Eg1HFfahurCmBt3FxgbYQ==",
             "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.46.0",
+                "@wordpress/hooks": "^3.47.0",
                 "gettext-parser": "^1.3.1",
                 "memize": "^2.1.0",
                 "sprintf-js": "^1.1.1",
@@ -27568,9 +27593,9 @@
             },
             "dependencies": {
                 "@wordpress/hooks": {
-                    "version": "3.46.0",
-                    "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.46.0.tgz",
-                    "integrity": "sha512-TTYNZwMZeATpkWmvAoShP43UONd/WPNTtsy1czMSyiqPzFhzGJbKD75CdJtPp5DqIAiuWQEuDmcxRAPcZ/1Qgw==",
+                    "version": "3.47.0",
+                    "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.47.0.tgz",
+                    "integrity": "sha512-a0mZ+lSUBrmacJGXDnFTaz1O47sQgTCZi3LrY445WNc7cmiSlscTfeBxrUXaTF0ninzHJnE7evCIeKLbQC3dLQ==",
                     "requires": {
                         "@babel/runtime": "^7.16.0"
                     }
@@ -27601,9 +27626,9 @@
             }
         },
         "@wordpress/jest-console": {
-            "version": "7.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.17.0.tgz",
-            "integrity": "sha512-i1r0fGEZforoB1C8QuSfDDYwMycAJ/MqkEvhqWNLwcJy/JFYGWiKhkzhKfQ7aMUuwtrEJMb+41AOxelT565bDw==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.18.0.tgz",
+            "integrity": "sha512-OjPGbU1HgjLVNCLW9ROmdkw/qhpFL6Svlfv1aUVBrq5z1nJ7SrjRMeBSq4LJloOhTasSV9z7w4mhHJkMkfolJg==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.16.0",
@@ -27611,12 +27636,12 @@
             }
         },
         "@wordpress/jest-preset-default": {
-            "version": "11.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.17.0.tgz",
-            "integrity": "sha512-Z1KAr9ViDLFiVAYsRkyAAwLBzxu6MTv1dAZpHhyZhYfxTNdTOnnHbNGHpsfv5OlT5xHxptkrESLP8klU2/kw4A==",
+            "version": "11.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.18.0.tgz",
+            "integrity": "sha512-qwcDXfKkdBJnnsQAa0qkBsg94usGQCD914pWNeBg997qy/6zmVYVXpPjXoJXaC/lYbEIRAWGfry1RSiM6ZoC9g==",
             "dev": true,
             "requires": {
-                "@wordpress/jest-console": "^7.17.0",
+                "@wordpress/jest-console": "^7.18.0",
                 "babel-jest": "^29.6.2"
             }
         },
@@ -27647,25 +27672,25 @@
             }
         },
         "@wordpress/npm-package-json-lint-config": {
-            "version": "4.31.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.31.0.tgz",
-            "integrity": "sha512-Y/MxST3sK/En6ZAChlyq5A7qtII9/1MLqk6o75yWPIDn1ew40V7iPBDkFKE3uMEPw1RW8rJ9WSQxNpcN+4k+Zg==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.32.0.tgz",
+            "integrity": "sha512-qyEnU9FoWpaa67pufu9fNmTCikiYhdKc4R01ffO+xX7wyJXMo0Z6EJog6ajU9E2+YL86AmAX+sO1CHuXcsxdbw==",
             "dev": true
         },
         "@wordpress/postcss-plugins-preset": {
-            "version": "4.30.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.30.0.tgz",
-            "integrity": "sha512-b/APWKhvocBrs+IHJNe7BOfFmvyRmOZEHEXvwPZy2iGIC95tA5p2/7h3/iSwUGNUcyGObqwd90Htfit9oIdQJA==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.31.0.tgz",
+            "integrity": "sha512-B6bHsCKxt25nkvWfIJH3l7kENKS20mpsiRIl5+CEES6kKfBwg4IPx+JyA/RPLFQcIQNtIYFft22p5bgT4VZcEg==",
             "dev": true,
             "requires": {
-                "@wordpress/base-styles": "^4.37.0",
+                "@wordpress/base-styles": "^4.38.0",
                 "autoprefixer": "^10.2.5"
             }
         },
         "@wordpress/prettier-config": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.3.0.tgz",
-            "integrity": "sha512-G0HoubSikorLtXs0CZ0TNGbhKImCr+Ztg0HQUKv683r+yiZBOQV1igk7TaHOmIaf6702Bt4E3++IoAQN8Nr5ew==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.4.0.tgz",
+            "integrity": "sha512-6qawlZqqbe6NDY0txzsPZThRFAXzf0a891wI/A4KNWVKUXQwTluXWMtGZx3xlFtvkX+9ZHdoqXbWysGQztiBOQ==",
             "dev": true
         },
         "@wordpress/primitives": {
@@ -27871,24 +27896,24 @@
             }
         },
         "@wordpress/scripts": {
-            "version": "26.17.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.17.0.tgz",
-            "integrity": "sha512-DmnZphBSkp9cX5YVAh9PchBh45iSaPFyh9Ria8rlH9zp/O5KQ2eWte4xv84B5FbKzUIqilNdtLTPrvsm0PQiGg==",
+            "version": "26.18.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.18.0.tgz",
+            "integrity": "sha512-cL3CKlPbH+JOnkV4MtGFUDys3KNlp6tjwrGBcpXsYOEm55DYtdXNmkRXHIfiM5hxCWiuE0P0dR7o/6F3Nz3TGA==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.16.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
                 "@svgr/webpack": "^8.0.1",
-                "@wordpress/babel-preset-default": "^7.30.0",
-                "@wordpress/browserslist-config": "^5.29.0",
-                "@wordpress/dependency-extraction-webpack-plugin": "^4.29.0",
-                "@wordpress/e2e-test-utils-playwright": "^0.14.0",
-                "@wordpress/eslint-plugin": "^17.3.0",
-                "@wordpress/jest-preset-default": "^11.17.0",
-                "@wordpress/npm-package-json-lint-config": "^4.31.0",
-                "@wordpress/postcss-plugins-preset": "^4.30.0",
-                "@wordpress/prettier-config": "^3.3.0",
-                "@wordpress/stylelint-config": "^21.29.0",
+                "@wordpress/babel-preset-default": "^7.31.0",
+                "@wordpress/browserslist-config": "^5.30.0",
+                "@wordpress/dependency-extraction-webpack-plugin": "^4.30.0",
+                "@wordpress/e2e-test-utils-playwright": "^0.15.0",
+                "@wordpress/eslint-plugin": "^17.4.0",
+                "@wordpress/jest-preset-default": "^11.18.0",
+                "@wordpress/npm-package-json-lint-config": "^4.32.0",
+                "@wordpress/postcss-plugins-preset": "^4.31.0",
+                "@wordpress/prettier-config": "^3.4.0",
+                "@wordpress/stylelint-config": "^21.30.0",
                 "adm-zip": "^0.5.9",
                 "babel-jest": "^29.6.2",
                 "babel-loader": "^8.2.3",
@@ -27907,7 +27932,7 @@
                 "fast-glob": "^3.2.7",
                 "filenamify": "^4.2.0",
                 "jest": "^29.6.2",
-                "jest-dev-server": "^6.0.2",
+                "jest-dev-server": "^9.0.1",
                 "jest-environment-jsdom": "^29.6.2",
                 "jest-environment-node": "^29.6.2",
                 "markdownlint-cli": "^0.31.1",
@@ -27937,9 +27962,9 @@
             }
         },
         "@wordpress/stylelint-config": {
-            "version": "21.29.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.29.0.tgz",
-            "integrity": "sha512-8VetLM5CTg8iLgodgpY4x132Yf4gPWMMffqfAG8HFwwvVQxm0mjl/dNtj6RBrxemdTi7dHr1jnZvqU+XxQlHXQ==",
+            "version": "21.30.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.30.0.tgz",
+            "integrity": "sha512-PlvXzYgjn7OUaVTy2bahSr6oL/eu1OdRWxrZfGVNxF4jRswND/ThqOEHIzxETNGTe0ggZOyY+40St4Swlo1zZQ==",
             "dev": true,
             "requires": {
                 "stylelint-config-recommended": "^6.0.0",
@@ -27975,9 +28000,9 @@
             }
         },
         "@wordpress/warning": {
-            "version": "2.46.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.46.0.tgz",
-            "integrity": "sha512-oyUNmDz64nF8vnS9LaobXMIx6K5w+XhAtvo3Cjv3kCVIuWFwpxoeMus3pUo1A7v2H9zcW+E87zwEuqsLPYjNfQ==",
+            "version": "2.47.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.47.0.tgz",
+            "integrity": "sha512-lmpLNI8Si7HrSY0LBBtp7Z6NzAkh1y7yeJI0LZw17EsJ0MM5FSXqXJRrNY7L4tM8G/vv3OacUw1mRAZX7bzBRQ==",
             "dev": true
         },
         "@xobotyi/scrollbar-width": {
@@ -28464,12 +28489,22 @@
             "dev": true
         },
         "axios": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.14.7"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            },
+            "dependencies": {
+                "proxy-from-env": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+                    "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                    "dev": true
+                }
             }
         },
         "axobject-query": {
@@ -28716,9 +28751,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "dev": true
         },
         "big.js": {
@@ -29692,9 +29727,9 @@
             }
         },
         "core-js": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-            "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+            "version": "3.33.3",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+            "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
             "dev": true
         },
         "core-js-compat": {
@@ -33774,18 +33809,18 @@
             }
         },
         "jest-dev-server": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.2.0.tgz",
-            "integrity": "sha512-ZWh8CuvxwjhYfvw4tGeftziqIvw/26R6AG3OTgNTQeXul8aZz48RQjDpnlDwnWX53jxJJl9fcigqIdSU5lYZuw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.1.tgz",
+            "integrity": "sha512-eqpJKSvVl4M0ojHZUPNbka8yEzLNbIMiINXDsuMF3lYfIdRO2iPqy+ASR4wBQ6nUyR3OT24oKPWhpsfLhgAVyg==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.2",
                 "cwd": "^0.10.0",
                 "find-process": "^1.4.7",
                 "prompts": "^2.4.2",
-                "spawnd": "^6.2.0",
+                "spawnd": "^9.0.1",
                 "tree-kill": "^1.2.2",
-                "wait-on": "^6.0.1"
+                "wait-on": "^7.0.1"
             }
         },
         "jest-diff": {
@@ -38410,14 +38445,21 @@
             }
         },
         "spawnd": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.2.0.tgz",
-            "integrity": "sha512-qX/I4lQy4KgVEcNle0kuc4FxFWHISzBhZW1YemPfwmrmQjyZmfTK/OhBKkhrD2ooAaFZEm1maEBLE6/6enwt+g==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.1.tgz",
+            "integrity": "sha512-vaMk8E9CpbjTYToBxLXowDeArGf1+yI7A6PU6Nr57b2g8BVY8nRi5vTBj3bMF8UkCrMdTMyf/Lh+lrcrW2z7pw==",
             "dev": true,
             "requires": {
-                "exit": "^0.1.2",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.1.0",
                 "tree-kill": "^1.2.2"
+            },
+            "dependencies": {
+                "signal-exit": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                    "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+                    "dev": true
+                }
             }
         },
         "spdx-correct": {
@@ -39831,16 +39873,16 @@
             }
         },
         "wait-on": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
-            "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
             "dev": true,
             "requires": {
-                "axios": "^0.25.0",
-                "joi": "^17.6.0",
+                "axios": "^1.6.1",
+                "joi": "^17.11.0",
                 "lodash": "^4.17.21",
-                "minimist": "^1.2.5",
-                "rxjs": "^7.5.4"
+                "minimist": "^1.2.8",
+                "rxjs": "^7.8.1"
             },
             "dependencies": {
                 "rxjs": {


### PR DESCRIPTION
Update logic to prevent SSO redirect to the plugin dashboard unless the split-test capability is set.
Also ensures that non-SSO logins don't redirect if the user isn't a site administrator.