### PR TITLE
Ecommerce bump version 1.3.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "newfold-labs/wp-module-coming-soon": "^1.2.0",
         "newfold-labs/wp-module-data": "^2.4.18",
         "newfold-labs/wp-module-deactivation": "^1.0.4",
-        "newfold-labs/wp-module-ecommerce": "^v1.3.21",
+        "newfold-labs/wp-module-ecommerce": "^v1.3.22",
         "newfold-labs/wp-module-global-ctb": "^1.0.10",
         "newfold-labs/wp-module-help-center": "^1.0.23",
         "newfold-labs/wp-module-loader": "^1.0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8425577a027f9bc937d56492edefd47",
+    "content-hash": "baa1e803cd2166b700630552e2650685",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -340,16 +340,16 @@
         },
         {
             "name": "newfold-labs/wp-module-deactivation",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-deactivation.git",
-                "reference": "e88fb69221430cac57bc4e19db2a2637719d250c"
+                "reference": "6706a53af02c1fd2b9cbe2ae88d53f28eec6e80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-deactivation/zipball/e88fb69221430cac57bc4e19db2a2637719d250c",
-                "reference": "e88fb69221430cac57bc4e19db2a2637719d250c",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-deactivation/zipball/6706a53af02c1fd2b9cbe2ae88d53f28eec6e80f",
+                "reference": "6706a53af02c1fd2b9cbe2ae88d53f28eec6e80f",
                 "shasum": ""
             },
             "require": {
@@ -394,23 +394,23 @@
             ],
             "description": "A Module for handling WordPress brand plugins and modules deactivations",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-deactivation/tree/1.0.4",
+                "source": "https://github.com/newfold-labs/wp-module-deactivation/tree/1.0.5",
                 "issues": "https://github.com/newfold-labs/wp-module-deactivation/issues"
             },
-            "time": "2024-01-11T21:43:25+00:00"
+            "time": "2024-02-08T18:34:32+00:00"
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",
-            "version": "v1.3.21",
+            "version": "v1.3.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ecommerce.git",
-                "reference": "a676d2f5d9914b191fb1db7c17d84c48287d6538"
+                "reference": "a4a50a8b2bbf86436b6bc1da6bb349a9585e8844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/a676d2f5d9914b191fb1db7c17d84c48287d6538",
-                "reference": "a676d2f5d9914b191fb1db7c17d84c48287d6538",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/a4a50a8b2bbf86436b6bc1da6bb349a9585e8844",
+                "reference": "a4a50a8b2bbf86436b6bc1da6bb349a9585e8844",
                 "shasum": ""
             },
             "require": {
@@ -453,23 +453,23 @@
             ],
             "description": "Brand Agnostic eCommerce Experience",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.21",
+                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.22",
                 "issues": "https://github.com/newfold-labs/wp-module-ecommerce/issues"
             },
-            "time": "2024-02-02T14:37:32+00:00"
+            "time": "2024-02-09T11:13:04+00:00"
         },
         {
             "name": "newfold-labs/wp-module-global-ctb",
-            "version": "1.0.10",
+            "version": "1.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-global-ctb.git",
-                "reference": "cbd8a5d6a4fcba184b15dc08ea2593f180b7da73"
+                "reference": "01bdafe902a928d2fa5eb9998cd4446512451b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-global-ctb/zipball/cbd8a5d6a4fcba184b15dc08ea2593f180b7da73",
-                "reference": "cbd8a5d6a4fcba184b15dc08ea2593f180b7da73",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-global-ctb/zipball/01bdafe902a928d2fa5eb9998cd4446512451b46",
+                "reference": "01bdafe902a928d2fa5eb9998cd4446512451b46",
                 "shasum": ""
             },
             "require-dev": {
@@ -503,10 +503,10 @@
             ],
             "description": "Newfold module for 'Click to Buy' functionality in brand plugins",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-global-ctb/tree/1.0.10",
+                "source": "https://github.com/newfold-labs/wp-module-global-ctb/tree/1.0.11",
                 "issues": "https://github.com/newfold-labs/wp-module-global-ctb/issues"
             },
-            "time": "2024-02-02T14:05:11+00:00"
+            "time": "2024-02-08T18:41:16+00:00"
         },
         {
             "name": "newfold-labs/wp-module-help-center",
@@ -556,16 +556,16 @@
         },
         {
             "name": "newfold-labs/wp-module-install-checker",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-install-checker.git",
-                "reference": "7d6574b297fb7a8a459ec9e53706bd956ef35490"
+                "reference": "9d43e916b8c4e752b45c868b41340b84bcb686a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-install-checker/zipball/7d6574b297fb7a8a459ec9e53706bd956ef35490",
-                "reference": "7d6574b297fb7a8a459ec9e53706bd956ef35490",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-install-checker/zipball/9d43e916b8c4e752b45c868b41340b84bcb686a6",
+                "reference": "9d43e916b8c4e752b45c868b41340b84bcb686a6",
                 "shasum": ""
             },
             "type": "library",
@@ -588,10 +588,10 @@
             ],
             "description": "A module that handles checking a WordPress installation to see if it is a fresh install and to fetch the estimated installation date.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-install-checker/tree/1.0.2",
+                "source": "https://github.com/newfold-labs/wp-module-install-checker/tree/1.0.3",
                 "issues": "https://github.com/newfold-labs/wp-module-install-checker/issues"
             },
-            "time": "2023-11-29T20:35:54+00:00"
+            "time": "2024-01-31T18:12:34+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",
@@ -740,16 +740,16 @@
         },
         {
             "name": "newfold-labs/wp-module-notifications",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-notifications.git",
-                "reference": "fea65e7cfa2e43c3fc9dd842e982e5d14d2059f9"
+                "reference": "f8ac38165a441e7a6ed90b0dde1edcfe2fb11139"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-notifications/zipball/fea65e7cfa2e43c3fc9dd842e982e5d14d2059f9",
-                "reference": "fea65e7cfa2e43c3fc9dd842e982e5d14d2059f9",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-notifications/zipball/f8ac38165a441e7a6ed90b0dde1edcfe2fb11139",
+                "reference": "f8ac38165a441e7a6ed90b0dde1edcfe2fb11139",
                 "shasum": ""
             },
             "require": {
@@ -778,10 +778,10 @@
             ],
             "description": "A module for managing Newfold in-site notifications.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-notifications/tree/1.2.3",
+                "source": "https://github.com/newfold-labs/wp-module-notifications/tree/1.2.4",
                 "issues": "https://github.com/newfold-labs/wp-module-notifications/issues"
             },
-            "time": "2024-02-02T13:43:42+00:00"
+            "time": "2024-02-08T18:38:31+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
@@ -2437,16 +2437,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.5.0",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "9cf9b40f6bad64ade8660cc26bf1f28f2d223268"
+                "reference": "ca7a44a1f8b09d533621b4006e739974212860ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/9cf9b40f6bad64ade8660cc26bf1f28f2d223268",
-                "reference": "9cf9b40f6bad64ade8660cc26bf1f28f2d223268",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/ca7a44a1f8b09d533621b4006e739974212860ee",
+                "reference": "ca7a44a1f8b09d533621b4006e739974212860ee",
                 "shasum": ""
             },
             "require": {
@@ -2474,6 +2474,7 @@
                     "i18n make-pot",
                     "i18n make-json",
                     "i18n make-mo",
+                    "i18n make-php",
                     "i18n update-po"
                 ]
             },
@@ -2499,9 +2500,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.5.0"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.0"
             },
-            "time": "2023-11-16T17:09:37+00:00"
+            "time": "2024-02-01T14:25:11+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -2619,16 +2620,16 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7"
+                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
-                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/a339dca576df73c31af4b4d8054efc2dab9a0685",
+                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685",
                 "shasum": ""
             },
             "require": {
@@ -2658,7 +2659,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9.x-dev"
+                    "dev-main": "2.10.x-dev"
                 }
             },
             "autoload": {
@@ -2685,7 +2686,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2023-10-25T09:06:37+00:00"
+            "time": "2024-02-08T16:52:43+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@heroicons/react": "^2.1.1",
-                "@newfold-labs/wp-module-ecommerce": "^1.3.21",
+                "@newfold-labs/wp-module-ecommerce": "^1.3.22",
                 "@newfold-labs/wp-module-runtime": "^1.0.9",
                 "@newfold/ui-component-library": "^1.0.1",
                 "@reduxjs/toolkit": "^2.1.0",
@@ -3133,9 +3133,9 @@
             "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
         },
         "node_modules/@newfold-labs/wp-module-ecommerce": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.21/718ef6a86f84b42ce4389c2b7b5cd626523e80a8",
-            "integrity": "sha512-eI7UvrYGuwCJ1EwG2HHnGzC+zVIqH8YbWjxnndEQryDLWKesQzs6OrBafUQCxaXG5O+HSArWeEV72gcfX7mbqA==",
+            "version": "1.3.22",
+            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.22/83ef4bf36a7fa9f7d5a254eb17be2be39fe56b2f",
+            "integrity": "sha512-PR7ZolQquH8C+CxyPqRmUJ259WDwBklgZZH+RA3hRwWrsOBc3UcoQUa/6F87F45KhdaS3F7P5vMOtjdRo0M1KA==",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@faizaanceg/pandora": "^1.1.1",
@@ -25100,9 +25100,9 @@
             }
         },
         "@newfold-labs/wp-module-ecommerce": {
-            "version": "1.3.21",
-            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.21/718ef6a86f84b42ce4389c2b7b5cd626523e80a8",
-            "integrity": "sha512-eI7UvrYGuwCJ1EwG2HHnGzC+zVIqH8YbWjxnndEQryDLWKesQzs6OrBafUQCxaXG5O+HSArWeEV72gcfX7mbqA==",
+            "version": "1.3.22",
+            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.22/83ef4bf36a7fa9f7d5a254eb17be2be39fe56b2f",
+            "integrity": "sha512-PR7ZolQquH8C+CxyPqRmUJ259WDwBklgZZH+RA3hRwWrsOBc3UcoQUa/6F87F45KhdaS3F7P5vMOtjdRo0M1KA==",
             "requires": {
                 "@faizaanceg/pandora": "^1.1.1",
                 "@heroicons/react": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@heroicons/react": "^2.1.1",
-        "@newfold-labs/wp-module-ecommerce": "^1.3.21",
+        "@newfold-labs/wp-module-ecommerce": "^1.3.22",
         "@newfold-labs/wp-module-runtime": "^1.0.9",
         "@newfold/ui-component-library": "^1.0.1",
         "@reduxjs/toolkit": "^2.1.0",


### PR DESCRIPTION
* PRESS4-469 | Remove possible text usage and comparisions from all cypress tests. by [@sangeetha-nayak](https://github.com/sangeetha-nayak) in [#211](https://github.com/newfold-labs/wp-module-ecommerce/pull/211)
* PRESS4-400 | yith plugin outbound links missing href by [@manikantakailasa](https://github.com/manikantakailasa) in [#175](https://github.com/newfold-labs/wp-module-ecommerce/pull/175)
* PRESS4-453 | Yith addons not enabling on store pageby [@manikantakailasa](https://github.com/manikantakailasa) in [#175](https://github.com/newfold-labs/wp-module-ecommerce/pull/175)
* Press4 465 Ordering woocomerce gateways and dismiss Woo payments CTA by [@mamatharao05](https://github.com/mamatharao05) in [#212](https://github.com/newfold-labs/wp-module-ecommerce/pull/212)
* PRESS4-470 | hostgator stripe changes
* Release 1.3.22 by [@manikantakailasa](https://github.com/manikantakailasa) in [#214](https://github.com/newfold-labs/wp-module-ecommerce/pull/214)