### PR TITLE
Fix failing Onboarding Cypress Tests

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,6 +10,9 @@
   "plugins": [
     "."
   ],
+  "themes": [
+    "https://downloads.wordpress.org/theme/yith-wonder.latest-stable.zip"
+  ],
   "port": 8884,
   "testsPort": 8885,
   "env": {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -74,6 +74,7 @@ module.exports = defineConfig({
 		testIsolation: false,
 		excludeSpecPattern: [
 			'vendor/newfold-labs/**/tests/cypress/integration/wp-module-support/*.cy.js', // skip any module's wp-module-support files
+			'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/5-AI-SiteGen-onboarding-flow'   // skip AI SiteGen Onboarding flow
 		],
 		experimentalRunAllSpecs: true,
 	},


### PR DESCRIPTION
- This PR will exclude the AI SiteGen Onboarding Tests for HG.
- Also, the design steps were failing because yith wonder was not getting pre-installed. So, added one step to install yith wonder while installing WordPress. (similar to BH plugin https://github.com/bluehost/bluehost-wordpress-plugin/blob/95396b3ac62f312a667f47e46b5e92e951487af1/.wp-env.json#L16)