### PR TITLE
Bump onboarding to 2.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "newfold-labs/wp-module-loader": "^1.0.10",
         "newfold-labs/wp-module-marketplace": "^2.2.4",
         "newfold-labs/wp-module-notifications": "^1.2.5",
-        "newfold-labs/wp-module-onboarding": "^2.1.3",
+        "newfold-labs/wp-module-onboarding": "^2.1.4",
         "newfold-labs/wp-module-patterns": "^0.1.14",
         "newfold-labs/wp-module-performance": "^1.4.0",
         "newfold-labs/wp-module-runtime": "^1.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2efb6ead5d5eb746e1ebe203f37c6dc2",
+    "content-hash": "728647dd52b6214542f24ac4355387bb",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -881,23 +881,23 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "a601bb0169332a6d41808554ce6fc137e9ae6a5c"
+                "reference": "a4c77fb24a3fbe3b69c3cc7af8bb0f19e36d13eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/a601bb0169332a6d41808554ce6fc137e9ae6a5c",
-                "reference": "a601bb0169332a6d41808554ce6fc137e9ae6a5c",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/a4c77fb24a3fbe3b69c3cc7af8bb0f19e36d13eb",
+                "reference": "a4c77fb24a3fbe3b69c3cc7af8bb0f19e36d13eb",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14",
                 "newfold-labs/wp-module-facebook": "^1.0.6",
                 "newfold-labs/wp-module-install-checker": "^1.0",
-                "newfold-labs/wp-module-onboarding-data": "^1.1.1",
+                "newfold-labs/wp-module-onboarding-data": "^1.1.2",
                 "newfold-labs/wp-module-patterns": "^0.1.14",
                 "wp-cli/wp-config-transformer": "^1.3",
                 "wp-forge/helpers": "^2.0"
@@ -936,28 +936,28 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.1.3",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.1.4",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2024-02-26T20:31:04+00:00"
+            "time": "2024-02-28T13:31:17+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "ef35d08c00da9df72ceae47b1bfb235c35db3008"
+                "reference": "aadf22bc17b6fb98cababa2e16dcff4d2c3a3dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/ef35d08c00da9df72ceae47b1bfb235c35db3008",
-                "reference": "ef35d08c00da9df72ceae47b1bfb235c35db3008",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/aadf22bc17b6fb98cababa2e16dcff4d2c3a3dd6",
+                "reference": "aadf22bc17b6fb98cababa2e16dcff4d2c3a3dd6",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14",
-                "newfold-labs/wp-module-ai": "^1.1.4",
+                "newfold-labs/wp-module-ai": "^1.1.5",
                 "newfold-labs/wp-module-coming-soon": "^1.2.0",
                 "newfold-labs/wp-module-data": "^2.4.18",
                 "newfold-labs/wp-module-installer": "^1.1",
@@ -982,10 +982,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.1",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.2",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2024-02-23T08:16:45+00:00"
+            "time": "2024-02-28T11:25:20+00:00"
         },
         {
             "name": "newfold-labs/wp-module-patterns",
@@ -3075,5 +3075,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Release Notes: 
https://github.com/newfold-labs/wp-module-onboarding/releases/tag/2.1.4