### PR TITLE
Ecommerce-version-bump-1.3.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "newfold-labs/wp-module-context": "^1.0",
         "newfold-labs/wp-module-data": "^2.4.18",
         "newfold-labs/wp-module-deactivation": "^1.0.5",
-        "newfold-labs/wp-module-ecommerce": "^1.3.23",
+        "newfold-labs/wp-module-ecommerce": "^1.3.24",
         "newfold-labs/wp-module-global-ctb": "^1.0.11",
         "newfold-labs/wp-module-help-center": "^1.0.23",
         "newfold-labs/wp-module-loader": "^1.0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2efb6ead5d5eb746e1ebe203f37c6dc2",
+    "content-hash": "095f82b117c0ce649d2dd55c5c098d3b",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -192,16 +192,16 @@
         },
         {
             "name": "newfold-labs/wp-module-ai",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ai.git",
-                "reference": "c8b776496904213476a7b79f0b431aac5837e1b3"
+                "reference": "de39aa47b11d68c763087ac26cca674068d47161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ai/zipball/c8b776496904213476a7b79f0b431aac5837e1b3",
-                "reference": "c8b776496904213476a7b79f0b431aac5837e1b3",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ai/zipball/de39aa47b11d68c763087ac26cca674068d47161",
+                "reference": "de39aa47b11d68c763087ac26cca674068d47161",
                 "shasum": ""
             },
             "require": {
@@ -230,23 +230,23 @@
             ],
             "description": "A module for providing artificial intelligence capabilities.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ai/tree/1.1.5",
+                "source": "https://github.com/newfold-labs/wp-module-ai/tree/1.1.6",
                 "issues": "https://github.com/newfold-labs/wp-module-ai/issues"
             },
-            "time": "2024-02-27T15:16:54+00:00"
+            "time": "2024-02-29T10:39:41+00:00"
         },
         {
             "name": "newfold-labs/wp-module-coming-soon",
-            "version": "1.2.0",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-coming-soon.git",
-                "reference": "74a6eab836e1d339f3650c68e89fd51b574e46bb"
+                "reference": "335bfe833ebdc072de55ed54cd6eebe0a210e43f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-coming-soon/zipball/74a6eab836e1d339f3650c68e89fd51b574e46bb",
-                "reference": "74a6eab836e1d339f3650c68e89fd51b574e46bb",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-coming-soon/zipball/335bfe833ebdc072de55ed54cd6eebe0a210e43f",
+                "reference": "335bfe833ebdc072de55ed54cd6eebe0a210e43f",
                 "shasum": ""
             },
             "require": {
@@ -284,10 +284,10 @@
             ],
             "description": "Coming Soon module for WordPress sites.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-coming-soon/tree/1.2.0",
+                "source": "https://github.com/newfold-labs/wp-module-coming-soon/tree/1.2.3",
                 "issues": "https://github.com/newfold-labs/wp-module-coming-soon/issues"
             },
-            "time": "2024-01-31T17:46:37+00:00"
+            "time": "2024-02-29T19:54:02+00:00"
         },
         {
             "name": "newfold-labs/wp-module-context",
@@ -455,16 +455,16 @@
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",
-            "version": "v1.3.23",
+            "version": "v1.3.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ecommerce.git",
-                "reference": "66d2f7c3c93780974987ce8566169220aee27e87"
+                "reference": "baabe57f9c14df3e976b3907ca34c4706df917c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/66d2f7c3c93780974987ce8566169220aee27e87",
-                "reference": "66d2f7c3c93780974987ce8566169220aee27e87",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/baabe57f9c14df3e976b3907ca34c4706df917c3",
+                "reference": "baabe57f9c14df3e976b3907ca34c4706df917c3",
                 "shasum": ""
             },
             "require": {
@@ -507,10 +507,10 @@
             ],
             "description": "Brand Agnostic eCommerce Experience",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.23",
+                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.24",
                 "issues": "https://github.com/newfold-labs/wp-module-ecommerce/issues"
             },
-            "time": "2024-02-22T16:51:37+00:00"
+            "time": "2024-03-12T12:49:07+00:00"
         },
         {
             "name": "newfold-labs/wp-module-facebook",
@@ -881,23 +881,23 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "2.1.3",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "a601bb0169332a6d41808554ce6fc137e9ae6a5c"
+                "reference": "8fc1a49b43b3db5d65bc42261c174dd7fd110c70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/a601bb0169332a6d41808554ce6fc137e9ae6a5c",
-                "reference": "a601bb0169332a6d41808554ce6fc137e9ae6a5c",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/8fc1a49b43b3db5d65bc42261c174dd7fd110c70",
+                "reference": "8fc1a49b43b3db5d65bc42261c174dd7fd110c70",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14",
                 "newfold-labs/wp-module-facebook": "^1.0.6",
                 "newfold-labs/wp-module-install-checker": "^1.0",
-                "newfold-labs/wp-module-onboarding-data": "^1.1.1",
+                "newfold-labs/wp-module-onboarding-data": "^1.1.3",
                 "newfold-labs/wp-module-patterns": "^0.1.14",
                 "wp-cli/wp-config-transformer": "^1.3",
                 "wp-forge/helpers": "^2.0"
@@ -936,33 +936,33 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.1.3",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.1.6",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2024-02-26T20:31:04+00:00"
+            "time": "2024-03-06T08:58:22+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "ef35d08c00da9df72ceae47b1bfb235c35db3008"
+                "reference": "a5e90dbdb748e2710f82654131b51973a6dabd12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/ef35d08c00da9df72ceae47b1bfb235c35db3008",
-                "reference": "ef35d08c00da9df72ceae47b1bfb235c35db3008",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/a5e90dbdb748e2710f82654131b51973a6dabd12",
+                "reference": "a5e90dbdb748e2710f82654131b51973a6dabd12",
                 "shasum": ""
             },
             "require": {
                 "mustache/mustache": "^2.14",
-                "newfold-labs/wp-module-ai": "^1.1.4",
-                "newfold-labs/wp-module-coming-soon": "^1.2.0",
+                "newfold-labs/wp-module-ai": "^1.1.6",
+                "newfold-labs/wp-module-coming-soon": "^1.2.3",
                 "newfold-labs/wp-module-data": "^2.4.18",
                 "newfold-labs/wp-module-installer": "^1.1",
                 "newfold-labs/wp-module-patterns": "^0.1.14",
-                "newfold-labs/wp-module-performance": "^1.3.0",
+                "newfold-labs/wp-module-performance": "^1.4.0",
                 "wp-forge/wp-upgrade-handler": "^1.0"
             },
             "require-dev": {
@@ -982,10 +982,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.1",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.3",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2024-02-23T08:16:45+00:00"
+            "time": "2024-03-04T13:57:20+00:00"
         },
         {
             "name": "newfold-labs/wp-module-patterns",
@@ -1976,16 +1976,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.16.1",
+            "version": "v1.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "f6e681062bb25c8dacbd30e079f4ad3fd890d7ad"
+                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/f6e681062bb25c8dacbd30e079f4ad3fd890d7ad",
-                "reference": "f6e681062bb25c8dacbd30e079f4ad3fd890d7ad",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/2791b08ffcc1862fe18eef85675da3aa58c406fe",
+                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe",
                 "shasum": ""
             },
             "require": {
@@ -1998,7 +1998,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.1-dev"
+                    "dev-master": "1.16.2-dev"
                 }
             },
             "autoload": {
@@ -2019,9 +2019,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.16.1"
+                "source": "https://github.com/mck89/peast/tree/v1.16.2"
             },
-            "time": "2024-02-14T08:15:19+00:00"
+            "time": "2024-03-05T09:16:03+00:00"
         },
         {
             "name": "newfold-labs/wp-php-standards",
@@ -2692,16 +2692,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "ca7a44a1f8b09d533621b4006e739974212860ee"
+                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/ca7a44a1f8b09d533621b4006e739974212860ee",
-                "reference": "ca7a44a1f8b09d533621b4006e739974212860ee",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
+                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
                 "shasum": ""
             },
             "require": {
@@ -2755,9 +2755,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.0"
+                "source": "https://github.com/wp-cli/i18n-command/tree/2.6.1"
             },
-            "time": "2024-02-01T14:25:11+00:00"
+            "time": "2024-02-28T11:27:34+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",

--- a/composer.lock
+++ b/composer.lock
@@ -345,24 +345,27 @@
         },
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.4.18",
+            "version": "2.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "f7bdfc1f70a2608c1ddaa6e3273221a880b794ed"
+                "reference": "f12eb13775497758dc7671ed57fb45a5f7c74c42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/f7bdfc1f70a2608c1ddaa6e3273221a880b794ed",
-                "reference": "f7bdfc1f70a2608c1ddaa6e3273221a880b794ed",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/f12eb13775497758dc7671ed57fb45a5f7c74c42",
+                "reference": "f12eb13775497758dc7671ed57fb45a5f7c74c42",
                 "shasum": ""
             },
             "require": {
+                "newfold-labs/wp-module-loader": "^1.0",
+                "wp-forge/helpers": "^2.0",
                 "wp-forge/wp-query-builder": "^1.0",
                 "wp-forge/wp-upgrade-handler": "^1.0",
                 "wpscholar/url": "^1.2"
             },
             "require-dev": {
+                "10up/wp_mock": "^0.4.2",
                 "newfold-labs/wp-php-standards": "^1.2"
             },
             "type": "library",
@@ -373,6 +376,11 @@
                 "files": [
                     "bootstrap.php"
                 ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\Data\\": "tests/phpunit/includes/"
+                }
             },
             "scripts": {
                 "fix": [
@@ -387,10 +395,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.18",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.19",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2024-01-24T21:36:38+00:00"
+            "time": "2024-03-13T20:15:30+00:00"
         },
         {
             "name": "newfold-labs/wp-module-deactivation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@heroicons/react": "^2.1.1",
-                "@newfold-labs/wp-module-ecommerce": "^1.3.23",
+                "@newfold-labs/wp-module-ecommerce": "^1.3.24",
                 "@newfold-labs/wp-module-runtime": "^1.0.9",
                 "@newfold/ui-component-library": "^1.0.1",
                 "@reduxjs/toolkit": "^2.1.0",
@@ -3133,9 +3133,9 @@
             "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
         },
         "node_modules/@newfold-labs/wp-module-ecommerce": {
-            "version": "1.3.23",
-            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.23/6cdfd95b644440b647934c3a87d1ea3a15ca05d1",
-            "integrity": "sha512-BNayu27u63dMhsHq3k1/I15sjOs7uVSskR92cpeI40NQiYRp2po6RlF4l23+DCKsjdxDJNtijC8d0dpHhmkWGw==",
+            "version": "1.3.24",
+            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.24/fe7d1d1c91bffe5d6ebe2b2d592e673cb35f74d5",
+            "integrity": "sha512-T7jgFNI4pftqaHrEA6fjX1VrlLnbxGnluKrttcI55gXJJQgz9m4Pn9kSRrGrPgOf9j3o5MT4yXj0SAML/1O+MQ==",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@faizaanceg/pandora": "^1.1.1",
@@ -25186,9 +25186,9 @@
             }
         },
         "@newfold-labs/wp-module-ecommerce": {
-            "version": "1.3.23",
-            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.23/6cdfd95b644440b647934c3a87d1ea3a15ca05d1",
-            "integrity": "sha512-BNayu27u63dMhsHq3k1/I15sjOs7uVSskR92cpeI40NQiYRp2po6RlF4l23+DCKsjdxDJNtijC8d0dpHhmkWGw==",
+            "version": "1.3.24",
+            "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.24/fe7d1d1c91bffe5d6ebe2b2d592e673cb35f74d5",
+            "integrity": "sha512-T7jgFNI4pftqaHrEA6fjX1VrlLnbxGnluKrttcI55gXJJQgz9m4Pn9kSRrGrPgOf9j3o5MT4yXj0SAML/1O+MQ==",
             "requires": {
                 "@faizaanceg/pandora": "^1.1.1",
                 "@heroicons/react": "2.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11976,20 +11976,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -31999,13 +31985,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
-        },
-        "fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "optional": true
         },
         "function-bind": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@heroicons/react": "^2.1.1",
-        "@newfold-labs/wp-module-ecommerce": "^1.3.23",
+        "@newfold-labs/wp-module-ecommerce": "^1.3.24",
         "@newfold-labs/wp-module-runtime": "^1.0.9",
         "@newfold/ui-component-library": "^1.0.1",
         "@reduxjs/toolkit": "^2.1.0",


### PR DESCRIPTION
What's changed?
Cypress Tests- Next Steps when Woo installed and active
PRESS4-504 | Paypal Login window pops up for Razorpay and Stripe connection
PRESS4-477 | updated coming soon page
PRESS4-492 | Resolving the warnings in wp-module-ecommerce in onboarding screen
PRESS4-486 | Ecommerce Features & Additional Features renaming
PRESS4-502 | Fixed Deprecated Warning
PRESS4-462 | Adding CTB to Yith products
PRESS4-497 | Renaming yith plugins on products page
PRESS4-464 | Adding Promotion option under marketing tab and products