### PR TITLE
update/ecommerce-version-bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "newfold-labs/wp-module-context": "^1.0.1",
         "newfold-labs/wp-module-data": "^2.5.2",
         "newfold-labs/wp-module-deactivation": "^1.1.2",
-        "newfold-labs/wp-module-ecommerce": "^1.3.32",
+        "newfold-labs/wp-module-ecommerce": "^1.3.33",
         "newfold-labs/wp-module-features": "^1.4.1",
         "newfold-labs/wp-module-global-ctb": "^1.0.12",
         "newfold-labs/wp-module-help-center": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "newfold-labs/wp-module-context": "^1.0.1",
         "newfold-labs/wp-module-data": "^2.5.2",
         "newfold-labs/wp-module-deactivation": "^1.1.2",
-        "newfold-labs/wp-module-ecommerce": "^1.3.31",
+        "newfold-labs/wp-module-ecommerce": "^1.3.32",
         "newfold-labs/wp-module-features": "^1.4.1",
         "newfold-labs/wp-module-global-ctb": "^1.0.12",
         "newfold-labs/wp-module-help-center": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3d22eb999404cd4ce77e55921c18cc0",
+    "content-hash": "0777e1499ceefae54fa1f4c73e6f89c1",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -627,16 +627,16 @@
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",
-            "version": "v1.3.32",
+            "version": "v1.3.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ecommerce.git",
-                "reference": "f984224d5e4436e34896940f5b8db14a1cc0aefd"
+                "reference": "9b848fee173f5688e4424dd010cad18914975678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/f984224d5e4436e34896940f5b8db14a1cc0aefd",
-                "reference": "f984224d5e4436e34896940f5b8db14a1cc0aefd",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/9b848fee173f5688e4424dd010cad18914975678",
+                "reference": "9b848fee173f5688e4424dd010cad18914975678",
                 "shasum": ""
             },
             "require": {
@@ -679,10 +679,10 @@
             ],
             "description": "Brand Agnostic eCommerce Experience",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.32",
+                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.33",
                 "issues": "https://github.com/newfold-labs/wp-module-ecommerce/issues"
             },
-            "time": "2024-06-12T09:56:35+00:00"
+            "time": "2024-06-18T08:53:05+00:00"
         },
         {
             "name": "newfold-labs/wp-module-facebook",
@@ -1066,16 +1066,16 @@
         },
         {
             "name": "newfold-labs/wp-module-migration",
-            "version": "v1.0.4",
+            "version": "v1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-migration.git",
-                "reference": "64e9c6cb82382fcc063e3362cf50dff9e89a148d"
+                "reference": "44cf5193ee2d6cff9424cf745308820755bb97e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-migration/zipball/64e9c6cb82382fcc063e3362cf50dff9e89a148d",
-                "reference": "64e9c6cb82382fcc063e3362cf50dff9e89a148d",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-migration/zipball/44cf5193ee2d6cff9424cf745308820755bb97e9",
+                "reference": "44cf5193ee2d6cff9424cf745308820755bb97e9",
                 "shasum": ""
             },
             "require": {
@@ -1113,10 +1113,10 @@
             ],
             "description": "Initiates the migration process",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-migration/tree/v1.0.4",
+                "source": "https://github.com/newfold-labs/wp-module-migration/tree/v1.0.5",
                 "issues": "https://github.com/newfold-labs/wp-module-migration/issues"
             },
-            "time": "2024-06-07T07:19:16+00:00"
+            "time": "2024-06-14T08:56:40+00:00"
         },
         {
             "name": "newfold-labs/wp-module-notifications",
@@ -1165,16 +1165,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "61bc13e39dee05de8fe9a13a0b68c69bc5bab83c"
+                "reference": "243277e79a3bd42f16b4d186f4575bf46fea67c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/61bc13e39dee05de8fe9a13a0b68c69bc5bab83c",
-                "reference": "61bc13e39dee05de8fe9a13a0b68c69bc5bab83c",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/243277e79a3bd42f16b4d186f4575bf46fea67c7",
+                "reference": "243277e79a3bd42f16b4d186f4575bf46fea67c7",
                 "shasum": ""
             },
             "require": {
@@ -1220,23 +1220,23 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.3",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.4",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2024-06-05T12:14:42+00:00"
+            "time": "2024-06-14T13:15:51+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "1.1.11",
+            "version": "1.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "16b522291f29fad9d3067da1634a7362ad889953"
+                "reference": "efce79142be2deb7382b0c500a17be75fc9a5708"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/16b522291f29fad9d3067da1634a7362ad889953",
-                "reference": "16b522291f29fad9d3067da1634a7362ad889953",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/efce79142be2deb7382b0c500a17be75fc9a5708",
+                "reference": "efce79142be2deb7382b0c500a17be75fc9a5708",
                 "shasum": ""
             },
             "require": {
@@ -1271,10 +1271,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.11",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.12",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2024-06-05T08:28:57+00:00"
+            "time": "2024-06-14T12:45:33+00:00"
         },
         {
             "name": "newfold-labs/wp-module-patterns",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fea61385b8b1c93e3b33c1723331017f",
+    "content-hash": "c3d22eb999404cd4ce77e55921c18cc0",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -627,16 +627,16 @@
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",
-            "version": "v1.3.31",
+            "version": "v1.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-ecommerce.git",
-                "reference": "24ef99c9b697f2c30172a95c5f6fa0470b9b2604"
+                "reference": "f984224d5e4436e34896940f5b8db14a1cc0aefd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/24ef99c9b697f2c30172a95c5f6fa0470b9b2604",
-                "reference": "24ef99c9b697f2c30172a95c5f6fa0470b9b2604",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-ecommerce/zipball/f984224d5e4436e34896940f5b8db14a1cc0aefd",
+                "reference": "f984224d5e4436e34896940f5b8db14a1cc0aefd",
                 "shasum": ""
             },
             "require": {
@@ -679,23 +679,23 @@
             ],
             "description": "Brand Agnostic eCommerce Experience",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.31",
+                "source": "https://github.com/newfold-labs/wp-module-ecommerce/tree/v1.3.32",
                 "issues": "https://github.com/newfold-labs/wp-module-ecommerce/issues"
             },
-            "time": "2024-05-20T12:40:55+00:00"
+            "time": "2024-06-12T09:56:35+00:00"
         },
         {
             "name": "newfold-labs/wp-module-facebook",
-            "version": "v1.0.7",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-facebook.git",
-                "reference": "77a433621894590b3d38c511d880d830fb3b4b64"
+                "reference": "5526497969f6a3fc4d4b2fa728ee1c9c52d132b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-facebook/zipball/77a433621894590b3d38c511d880d830fb3b4b64",
-                "reference": "77a433621894590b3d38c511d880d830fb3b4b64",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-facebook/zipball/5526497969f6a3fc4d4b2fa728ee1c9c52d132b8",
+                "reference": "5526497969f6a3fc4d4b2fa728ee1c9c52d132b8",
                 "shasum": ""
             },
             "require": {
@@ -721,10 +721,10 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-facebook/tree/v1.0.7",
+                "source": "https://github.com/newfold-labs/wp-module-facebook/tree/v1.0.9",
                 "issues": "https://github.com/newfold-labs/wp-module-facebook/issues"
             },
-            "time": "2024-05-03T10:09:41+00:00"
+            "time": "2024-06-05T11:02:38+00:00"
         },
         {
             "name": "newfold-labs/wp-module-features",
@@ -1066,16 +1066,16 @@
         },
         {
             "name": "newfold-labs/wp-module-migration",
-            "version": "v1.0.2",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-migration.git",
-                "reference": "6c14249e1aba88bf23434352301f55649074dd68"
+                "reference": "64e9c6cb82382fcc063e3362cf50dff9e89a148d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-migration/zipball/6c14249e1aba88bf23434352301f55649074dd68",
-                "reference": "6c14249e1aba88bf23434352301f55649074dd68",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-migration/zipball/64e9c6cb82382fcc063e3362cf50dff9e89a148d",
+                "reference": "64e9c6cb82382fcc063e3362cf50dff9e89a148d",
                 "shasum": ""
             },
             "require": {
@@ -1113,10 +1113,10 @@
             ],
             "description": "Initiates the migration process",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-migration/tree/v1.0.2",
+                "source": "https://github.com/newfold-labs/wp-module-migration/tree/v1.0.4",
                 "issues": "https://github.com/newfold-labs/wp-module-migration/issues"
             },
-            "time": "2024-05-16T12:09:32+00:00"
+            "time": "2024-06-07T07:19:16+00:00"
         },
         {
             "name": "newfold-labs/wp-module-notifications",
@@ -1165,16 +1165,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "2.3.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "411ffa50a12a040213be6204e5f27612b7974286"
+                "reference": "61bc13e39dee05de8fe9a13a0b68c69bc5bab83c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/411ffa50a12a040213be6204e5f27612b7974286",
-                "reference": "411ffa50a12a040213be6204e5f27612b7974286",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/61bc13e39dee05de8fe9a13a0b68c69bc5bab83c",
+                "reference": "61bc13e39dee05de8fe9a13a0b68c69bc5bab83c",
                 "shasum": ""
             },
             "require": {
@@ -1220,23 +1220,23 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.1",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.3",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2024-05-16T11:37:24+00:00"
+            "time": "2024-06-05T12:14:42+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
-            "version": "1.1.9",
+            "version": "1.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding-data.git",
-                "reference": "7d61b2fc732ddfb2d67d7dfe6bfec4851b3996a8"
+                "reference": "16b522291f29fad9d3067da1634a7362ad889953"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/7d61b2fc732ddfb2d67d7dfe6bfec4851b3996a8",
-                "reference": "7d61b2fc732ddfb2d67d7dfe6bfec4851b3996a8",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding-data/zipball/16b522291f29fad9d3067da1634a7362ad889953",
+                "reference": "16b522291f29fad9d3067da1634a7362ad889953",
                 "shasum": ""
             },
             "require": {
@@ -1271,10 +1271,10 @@
             ],
             "description": "A non-toggleable module containing a standardized interface for interacting with Onboarding data.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.9",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding-data/tree/1.1.11",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding-data/issues"
             },
-            "time": "2024-05-16T10:57:14+00:00"
+            "time": "2024-06-05T08:28:57+00:00"
         },
         {
             "name": "newfold-labs/wp-module-patterns",
@@ -2646,22 +2646,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -2730,20 +2730,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-24T11:47:18+00:00"
+            "time": "2024-05-20T13:34:27+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "57e09801c2fbae2d257b8b75bebb3deeb7e9deb2"
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/57e09801c2fbae2d257b8b75bebb3deeb7e9deb2",
-                "reference": "57e09801c2fbae2d257b8b75bebb3deeb7e9deb2",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
                 "shasum": ""
             },
             "require": {
@@ -2810,7 +2810,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-20T08:11:32+00:00"
+            "time": "2024-05-22T21:24:41+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2881,16 +2881,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.39",
+            "version": "v5.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a"
+                "reference": "f51cff4687547641c7d8180d74932ab40b2205ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/f6a96e4fcd468a25fede16ee665f50ced856bd0a",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/f51cff4687547641c7d8180d74932ab40b2205ce",
+                "reference": "f51cff4687547641c7d8180d74932ab40b2205ce",
                 "shasum": ""
             },
             "require": {
@@ -2924,7 +2924,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.39"
+                "source": "https://github.com/symfony/finder/tree/v5.4.40"
             },
             "funding": [
                 {
@@ -2940,7 +2940,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -3343,7 +3343,7 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.5.3",
+            "version": "6.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
-        "@newfold-labs/wp-module-ecommerce": "^1.3.31",
+        "@newfold-labs/wp-module-ecommerce": "^1.3.32",
         "@newfold-labs/wp-module-runtime": "^1.0.11",
         "@newfold/ui-component-library": "^1.1.0",
         "@reduxjs/toolkit": "^2.1.0",
@@ -3156,9 +3156,9 @@
       }
     },
     "node_modules/@newfold-labs/wp-module-ecommerce": {
-      "version": "1.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.31/355c4a15cc4d8cc4820a8db6de508e511d938c42",
-      "integrity": "sha512-3T9MPz9v/dtyUuO0TAlJONhunZ2SNGbHCOuYKx7ffge6esO6wYFYB2m9B7FoP1wC8Rl/zvfwxQfKTooS6LHLHA==",
+      "version": "1.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.32/38d03cc4d731e9dd6b958b3a7393ae2824ee7b30",
+      "integrity": "sha512-xiNnF21m1nvilEw+sYTs/ZctY7N2YTmBE2WvfIfxhnQDdLXH0DbWDIZye0Lhdbb9xp8F8doGO4pHlekRizCxsA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
-        "@newfold-labs/wp-module-ecommerce": "^1.3.32",
+        "@newfold-labs/wp-module-ecommerce": "^1.3.33",
         "@newfold-labs/wp-module-runtime": "^1.0.11",
         "@newfold/ui-component-library": "^1.1.0",
         "@reduxjs/toolkit": "^2.1.0",
@@ -3156,9 +3156,9 @@
       }
     },
     "node_modules/@newfold-labs/wp-module-ecommerce": {
-      "version": "1.3.32",
-      "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.32/38d03cc4d731e9dd6b958b3a7393ae2824ee7b30",
-      "integrity": "sha512-xiNnF21m1nvilEw+sYTs/ZctY7N2YTmBE2WvfIfxhnQDdLXH0DbWDIZye0Lhdbb9xp8F8doGO4pHlekRizCxsA==",
+      "version": "1.3.33",
+      "resolved": "https://npm.pkg.github.com/download/@newfold-labs/wp-module-ecommerce/1.3.33/5b3282eb4b7afb48ff4dd45c358dd66b049bca9d",
+      "integrity": "sha512-XRiXm7bG4TW8cGaoTPcMSWSQ0o9t7YBiZZTTsKMBAnbIQwc5qkQGdrrSvb2bMzyuEXUYIbtxA+mJpCuO6defJw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@faizaanceg/pandora": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
-    "@newfold-labs/wp-module-ecommerce": "^1.3.31",
+    "@newfold-labs/wp-module-ecommerce": "^1.3.32",
     "@newfold-labs/wp-module-runtime": "^1.0.11",
     "@newfold/ui-component-library": "^1.1.0",
     "@reduxjs/toolkit": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
-    "@newfold-labs/wp-module-ecommerce": "^1.3.32",
+    "@newfold-labs/wp-module-ecommerce": "^1.3.33",
     "@newfold-labs/wp-module-runtime": "^1.0.11",
     "@newfold/ui-component-library": "^1.1.0",
     "@reduxjs/toolkit": "^2.1.0",


### PR DESCRIPTION
Following are the changes updated in ECommerce Module release 1.3.33

* `PRESS0-1325`: Post Migration scripts
* `PRESS0-1159`: Update Store Home Page 
* `PRESS0-1448`: Remove Unused Thumbnail Service Code 
* Ecommerce version bump 1.3.33 